### PR TITLE
Use pure node functions to run move commands for os compatibility

### DIFF
--- a/templates/fungible-asset-template/frontend/package.json
+++ b/templates/fungible-asset-template/frontend/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.0",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.14.0",
-    "@aptos-labs/wallet-adapter-ant-design": "^2.2.6",
-    "@aptos-labs/wallet-adapter-react": "^2.3.7",
+    "@aptos-labs/wallet-adapter-ant-design": "^2.3.0",
+    "@aptos-labs/wallet-adapter-react": "^2.4.0",
     "@pontem/wallet-adapter-plugin": "^0.2.0",
     "petra-plugin-wallet-adapter": "^0.3.0",
     "react": "^18.2.0",

--- a/templates/fungible-asset-template/frontend/package.json
+++ b/templates/fungible-asset-template/frontend/package.json
@@ -6,7 +6,6 @@
     "@aptos-labs/wallet-adapter-ant-design": "^2.3.0",
     "@aptos-labs/wallet-adapter-react": "^2.4.0",
     "@pontem/wallet-adapter-plugin": "^0.2.0",
-    "petra-plugin-wallet-adapter": "^0.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/templates/fungible-asset-template/frontend/src/main.tsx
+++ b/templates/fungible-asset-template/frontend/src/main.tsx
@@ -3,13 +3,12 @@ import ReactDOM from "react-dom/client";
 // wallet adapter
 import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
 // wallets
-import { PetraWallet } from "petra-plugin-wallet-adapter";
 import { PontemWallet } from "@pontem/wallet-adapter-plugin";
 
 import App from "./App";
 import "./index.css";
 
-const wallets = [new PetraWallet(), new PontemWallet()];
+const wallets = [new PontemWallet()];
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/templates/fungible-asset-template/package.json
+++ b/templates/fungible-asset-template/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "aptos-dapp-boilerplate",
+  "name": "fungible-asset-template",
   "license": "Apache-2.0",
   "version": "0.0.0",
   "scripts": {
-    "move:init": "export $(cat .env | xargs) && aptos init --network=$VITE_APP_NETWORK --profile=$VITE_APP_NETWORK",
-    "move:compile": "export $(cat .env | xargs) && aptos move compile --package-dir move --skip-fetch-latest-git-deps --named-addresses module_addr=$(./scripts/get_module_addr.sh)",
-    "move:test": "export $(cat .env | xargs) && aptos move test --package-dir move --skip-fetch-latest-git-deps --named-addresses module_addr=$(./scripts/get_module_addr.sh)",
-    "move:publish": "export $(cat .env | xargs) && aptos move publish --package-dir move --skip-fetch-latest-git-deps --named-addresses module_addr=$(./scripts/get_module_addr.sh) --profile=$VITE_APP_NETWORK && ./scripts/gen_abi.sh"
+    "move:init": "node ./scripts/init && node ./scripts/update_env",
+    "move:compile": "node ./scripts/move/compile",
+    "move:test": "node ./scripts/move/test",
+    "move:publish": "node ./scripts/move/publish"
   },
   "devDependencies": {
-    "@aptos-labs/aptos-cli": "latest"
+    "@aptos-labs/ts-sdk": "1.15.0",
+    "js-yaml": "4.1.0",
+    "dotenv": "16.3.1",
+    "tree-kill": "1.2.2"
   }
 }

--- a/templates/fungible-asset-template/package.json
+++ b/templates/fungible-asset-template/package.json
@@ -8,8 +8,10 @@
     "move:test": "node ./scripts/move/test",
     "move:publish": "node ./scripts/move/publish"
   },
+  "dependencies": {
+    "@aptos-labs/ts-sdk": "1.16.0"
+  },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": "1.15.0",
     "js-yaml": "4.1.0",
     "dotenv": "16.3.1",
     "tree-kill": "1.2.2"

--- a/templates/fungible-asset-template/scripts/gen_abi.sh
+++ b/templates/fungible-asset-template/scripts/gen_abi.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-
-MODULE_ADDR=$(./scripts/get_module_addr.sh)
-PACKAGE_NAME=$(cat move/sources/$(ls move/sources/ | head -n 1) | head -n 1 | sed -n 's/module [^:]*::\(.*\) {/\1/p')
-export $(cat .env | xargs) && echo "export const ABI = $(curl https://fullnode.$VITE_APP_NETWORK.aptoslabs.com/v1/accounts/$MODULE_ADDR/module/$PACKAGE_NAME | sed -n 's/.*"abi":\({.*}\).*}$/\1/p') as const" > frontend/src/abi.ts

--- a/templates/fungible-asset-template/scripts/get_module_addr.sh
+++ b/templates/fungible-asset-template/scripts/get_module_addr.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-export $(cat .env | xargs) && echo 0x$(npx aptos config show-profiles --profile=$VITE_APP_NETWORK | grep 'account' | sed -n 's/.*"account": \"\(.*\)\".*/\1/p');

--- a/templates/fungible-asset-template/scripts/init.js
+++ b/templates/fungible-asset-template/scripts/init.js
@@ -1,0 +1,13 @@
+require("dotenv").config();
+
+const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
+
+async function init() {
+  const move = new cli.Move();
+
+  await move.init({
+    network: process.env.VITE_APP_NETWORK,
+    profile: process.env.VITE_APP_NETWORK,
+  });
+}
+init();

--- a/templates/fungible-asset-template/scripts/move/compile.js
+++ b/templates/fungible-asset-template/scripts/move/compile.js
@@ -1,0 +1,20 @@
+require("dotenv").config();
+const fs = require("node:fs");
+const yaml = require("js-yaml");
+const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
+
+const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
+const accountAddress =
+  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+
+async function compile() {
+  const move = new cli.Move();
+
+  await move.compile({
+    packageDirectoryPath: "move",
+    namedAddresses: {
+      module_addr: accountAddress, // make module_addr generic and fetch from Move.toml file
+    },
+  });
+}
+compile();

--- a/templates/fungible-asset-template/scripts/move/publish.js
+++ b/templates/fungible-asset-template/scripts/move/publish.js
@@ -1,0 +1,21 @@
+require("dotenv").config();
+const fs = require("node:fs");
+const yaml = require("js-yaml");
+const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
+
+const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
+const accountAddress =
+  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+
+async function publish() {
+  const move = new cli.Move();
+
+  await move.publish({
+    packageDirectoryPath: "move",
+    namedAddresses: {
+      module_addr: accountAddress, // make module_addr generic and fetch from Move.toml file
+    },
+    profile: process.env.VITE_APP_NETWORK,
+  });
+}
+publish();

--- a/templates/fungible-asset-template/scripts/move/test.js
+++ b/templates/fungible-asset-template/scripts/move/test.js
@@ -1,0 +1,20 @@
+require("dotenv").config();
+const fs = require("node:fs");
+const yaml = require("js-yaml");
+const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
+
+const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
+const accountAddress =
+  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+
+async function test() {
+  const move = new cli.Move();
+
+  await move.test({
+    packageDirectoryPath: "move",
+    namedAddresses: {
+      module_addr: accountAddress, // make module_addr generic and fetch from Move.toml file
+    },
+  });
+}
+test();

--- a/templates/fungible-asset-template/scripts/update_env.js
+++ b/templates/fungible-asset-template/scripts/update_env.js
@@ -1,0 +1,10 @@
+const fs = require("node:fs");
+const yaml = require("js-yaml");
+require("dotenv").config();
+
+const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
+const accountAddress =
+  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+
+fs.appendFileSync(".env", `\nVITE_MODULE_ADDRESS=0x${accountAddress}`);
+fs.appendFileSync("frontend/.env", `\nVITE_MODULE_ADDRESS=0x${accountAddress}`);


### PR DESCRIPTION
Use Node functions when running Move commands in the tool for OS compatibility (instead of running Mac only supported commands)

Tested on both Mac and Windows machines