### PR TITLE
Remove devnet from network options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type Result = prompts.Answers<"projectName" | "template" | "network">;
 
 export type Template = "digital-asset-template";
 
-export type Network = "mainnet" | "testnet" | "devnet";
+export type Network = "mainnet" | "testnet";
 
 export type Selections = {
   projectName: string;

--- a/src/workflowOptions.ts
+++ b/src/workflowOptions.ts
@@ -28,7 +28,6 @@ export const workflowOptions = {
     choices: [
       { title: "Mainnet", value: "mainnet" },
       { title: "Testnet", value: "testnet" },
-      { title: "Devnet", value: "devnet" },
     ],
     initial: 0,
     hint: "- You can change this later",


### PR DESCRIPTION
Remove `devnet` as a network option since we dont support it with the initial templates (Irys only supports mainnet / testnet)