### PR TITLE
Override VITE_MODULE_ADDRESS variable if exists

### DIFF
--- a/templates/digital-asset-template/scripts/update_env.js
+++ b/templates/digital-asset-template/scripts/update_env.js
@@ -6,5 +6,26 @@ const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
   config["profiles"][process.env.VITE_APP_NETWORK]["account"];
 
-fs.appendFileSync(".env", `\nVITE_MODULE_ADDRESS=0x${accountAddress}`);
-fs.appendFileSync("frontend/.env", `\nVITE_MODULE_ADDRESS=0x${accountAddress}`);
+const filePath = ".env";
+let envContent = "";
+
+// Check .env file exists and read it
+if (fs.existsSync(filePath)) {
+  envContent = fs.readFileSync(filePath, "utf8");
+}
+
+// Regular expression to match the VITE_MODULE_ADDRESS variable
+const regex = /^VITE_MODULE_ADDRESS=.*$/m;
+const newEntry = `VITE_MODULE_ADDRESS=0x${accountAddress}`;
+
+// Check if VITE_MODULE_ADDRESS is already defined
+if (envContent.match(regex)) {
+  // If the variable exists, replace it with the new value
+  envContent = envContent.replace(regex, newEntry);
+} else {
+  // If the variable does not exist, append it
+  envContent += `\n${newEntry}`;
+}
+
+// Write the updated content back to the .env file
+fs.writeFileSync(filePath, envContent, "utf8");

--- a/templates/fungible-asset-template/scripts/update_env.js
+++ b/templates/fungible-asset-template/scripts/update_env.js
@@ -6,4 +6,26 @@ const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
   config["profiles"][process.env.VITE_APP_NETWORK]["account"];
 
-fs.appendFileSync(".env", `\nVITE_MODULE_ADDRESS=0x${accountAddress}`);
+const filePath = ".env";
+let envContent = "";
+
+// Check .env file exists and read it
+if (fs.existsSync(filePath)) {
+  envContent = fs.readFileSync(filePath, "utf8");
+}
+
+// Regular expression to match the VITE_MODULE_ADDRESS variable
+const regex = /^VITE_MODULE_ADDRESS=.*$/m;
+const newEntry = `VITE_MODULE_ADDRESS=0x${accountAddress}`;
+
+// Check if VITE_MODULE_ADDRESS is already defined
+if (envContent.match(regex)) {
+  // If the variable exists, replace it with the new value
+  envContent = envContent.replace(regex, newEntry);
+} else {
+  // If the variable does not exist, append it
+  envContent += `\n${newEntry}`;
+}
+
+// Write the updated content back to the .env file
+fs.writeFileSync(filePath, envContent, "utf8");


### PR DESCRIPTION
There is a bug if we run `npm run move:init` multiple times (so we create new profile accounts) the `VITE_MODULE_ADDRESS` variable is being appended instead of replaced