### PR TITLE
Various improvements on NFT contract

### DIFF
--- a/templates/digital-asset-template/move/sources/launchpad.move
+++ b/templates/digital-asset-template/move/sources/launchpad.move
@@ -474,7 +474,6 @@ module launchpad_addr::launchpad {
             return
         };
 
-        assert!(option::is_some(&public_mint_end_time), EEND_TIME_MUST_BE_SET_FOR_STAGE);
         assert!(option::is_some(&public_mint_limit_per_addr), EMINT_LIMIT_PER_ADDR_MUST_BE_SET_FOR_STAGE);
         assert!(option::is_some(&public_mint_fee_per_nft), EMINT_FEE_PER_NFT_MUST_BE_SET_FOR_STAGE);
 

--- a/templates/digital-asset-template/move/sources/launchpad.move
+++ b/templates/digital-asset-template/move/sources/launchpad.move
@@ -29,7 +29,9 @@ module launchpad_addr::launchpad {
     /// Only admin can create collection
     const EONLY_ADMIN_CAN_CREATE_COLLECTION: u64 = 4;
     /// No active mint stages
-    const E_NO_ACTIVE_STAGES: u64 = 5;
+    const ENO_ACTIVE_STAGES: u64 = 5;
+    /// Creator must set at least one mint stage
+    const EAT_LEAST_ONE_STAGE_IS_REQUIRED: u64 = 6;
 
     const ALLOWLIST_MINT_STAGE_CATEGORY: vector<u8> = b"Allowlist mint stage";
     const PUBLIC_MINT_MINT_STAGE_CATEGORY: vector<u8> = b"Public mint mint stage";
@@ -204,6 +206,11 @@ module launchpad_addr::launchpad {
             collection_owner_obj,
         });
 
+        assert!(
+            option::is_some(&allowlist) || option::is_some(&public_mint_start_time),
+            EAT_LEAST_ONE_STAGE_IS_REQUIRED
+        );
+
         if (option::is_some(&allowlist)) {
             let allowlist = *option::borrow(&allowlist);
             let stage = string::utf8(ALLOWLIST_MINT_STAGE_CATEGORY);
@@ -303,7 +310,7 @@ module launchpad_addr::launchpad {
         let sender_addr = signer::address_of(sender);
 
         let stage_idx = &mint_stage::execute_earliest_stage(sender, collection_obj, 1);
-        assert!(option::is_some(stage_idx), E_NO_ACTIVE_STAGES);
+        assert!(option::is_some(stage_idx), ENO_ACTIVE_STAGES);
 
         let stage_obj = mint_stage::find_mint_stage_by_index(collection_obj, *option::borrow(stage_idx));
         let stage_name = mint_stage::mint_stage_name(stage_obj);
@@ -328,11 +335,11 @@ module launchpad_addr::launchpad {
         let sender_addr = signer::address_of(sender);
 
         let stage_idx = &mint_stage::execute_earliest_stage(sender, collection_obj, amount);
-        assert!(option::is_some(stage_idx), E_NO_ACTIVE_STAGES);
+        assert!(option::is_some(stage_idx), ENO_ACTIVE_STAGES);
 
         let stage_obj = mint_stage::find_mint_stage_by_index(collection_obj, *option::borrow(stage_idx));
         let stage_name = mint_stage::mint_stage_name(stage_obj);
-        let total_mint_fee = amount * get_mint_fee_per_nft(collection_obj,  stage_name);
+        let total_mint_fee = amount * get_mint_fee_per_nft(collection_obj, stage_name);
         pay_for_mint(sender, total_mint_fee);
 
         let nft_objs = vector[];

--- a/templates/digital-asset-template/move/sources/launchpad.move
+++ b/templates/digital-asset-template/move/sources/launchpad.move
@@ -33,6 +33,8 @@ module launchpad_addr::launchpad {
     /// Creator must set at least one mint stage
     const EAT_LEAST_ONE_STAGE_IS_REQUIRED: u64 = 6;
 
+    const ONE_HUNDRED_YEARS_IN_SECONDS: u64 = 100 * 365 * 24 * 60 * 60;
+
     const ALLOWLIST_MINT_STAGE_CATEGORY: vector<u8> = b"Allowlist mint stage";
     const PUBLIC_MINT_MINT_STAGE_CATEGORY: vector<u8> = b"Public mint mint stage";
 
@@ -245,7 +247,7 @@ module launchpad_addr::launchpad {
                 collection_obj_signer,
                 stage,
                 *option::borrow(&public_mint_start_time),
-                *option::borrow(&public_mint_end_time),
+                *option::borrow_with_default(&public_mint_end_time, &ONE_HUNDRED_YEARS_IN_SECONDS),
             );
 
             let stage_idx = mint_stage::find_mint_stage_index_by_name(collection_obj, stage);

--- a/templates/digital-asset-template/move/sources/launchpad.move
+++ b/templates/digital-asset-template/move/sources/launchpad.move
@@ -232,7 +232,7 @@ module launchpad_addr::launchpad {
             );
         };
 
-        if (option::is_some(&public_mint_end_time)) {
+        if (option::is_some(&public_mint_start_time)) {
             let stage = string::utf8(PUBLIC_MINT_MINT_STAGE_CATEGORY);
             mint_stage::create(
                 collection_obj_signer,


### PR DESCRIPTION
1. Add view function to get start and end time of active or next mint stage. Frontend can first call `get_active_or_next_mint_stage()` to the stage name, then call `get_mint_stage_start_and_end_time()`
2. Default public mint end time to 100 years so frontend can set it to undefined. 
