### PR TITLE
Update wizard flow following latest contract changes

### DIFF
--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -29,7 +29,7 @@ export async function generateDapp(selection: Selections) {
   const templateDir = path.resolve(
     fileURLToPath(import.meta.url),
     "../../templates",
-    selection.template
+    selection.template.path
   );
 
   // current working directory
@@ -94,7 +94,7 @@ export async function generateDapp(selection: Selections) {
 
     // create .env file
     const network = selection.network || "testnet";
-    await write(".env", `VITE_APP_NETWORK=${network}`);
+    await write(".env", `VITE_APP_NETWORK=${network}\nVITE_CREATOR_ADDRESS=""`);
 
     // Log next steps
     console.log(
@@ -102,37 +102,15 @@ export async function generateDapp(selection: Selections) {
     );
 
     console.log(bold("\nNext steps:") + "\n");
-    console.log(
-      green(`1. run ${white(`cd ${projectName}`)} to your dapp directory.`) +
-        "\n"
-    );
-    console.log(
-      green(
-        `2. run ${white("npm run move:init")} to initialize a new CLI Profile.`
-      ) + "\n"
-    );
-    console.log(
-      green(
-        `2. run ${white("npm run move:test")} to run move module unit tests.`
-      ) + "\n"
-    );
-    console.log(
-      green(
-        `3. run ${white("npm run move:compile")} to compile your move contract.`
-      ) + "\n"
-    );
-    console.log(
-      green(
-        `4. run ${white("npm run move:publish")} to publish your contract.`
-      ) + "\n"
-    );
-    console.log(
-      green(`5. run ${white("npm run dev")} to run your dapp.`) + "\n"
-    );
 
+    console.log(green(`1. cd ${projectName}`) + "\n");
+    console.log(green(`2. npm run dev`) + "\n");
     console.log(
-      green(`6. open up your project in your favorite IDE and start coding!`) +
-        "\n"
+      green(
+        `3. Follow the instructions for the ${
+          selection.template.name
+        } template on ${white(selection.template.doc)}`
+      )
     );
   } catch (error: any) {
     currentSpinner?.fail(`Failed to scaffold project: ${error.message}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,11 @@ import prompts from "prompts";
 
 export type Result = prompts.Answers<"projectName" | "template" | "network">;
 
-export type Template = "digital-asset-template";
+export type Template = {
+  name: string;
+  path: string;
+  doc: string;
+};
 
 export type Network = "mainnet" | "testnet";
 

--- a/src/workflowOptions.ts
+++ b/src/workflowOptions.ts
@@ -15,13 +15,21 @@ export const workflowOptions = {
     choices: [
       {
         title: "Digital Asset",
-        value: "digital-asset-template",
-        description: "A dapp to mint a digital asset",
+        value: {
+          path: "digital-asset-template",
+          name: "Digital Asset",
+          doc: "https://aptos.dev/digital", // TODO fill with real url once doc is live
+        },
+        description: "A NFT minting dapp",
       },
       {
         title: "Fungible Asset",
-        value: "fungible-asset-template",
-        description: "A dapp to mint a fungible asset",
+        value: {
+          path: "fungible-asset-template",
+          name: "Fungible Asset",
+          doc: "https://aptos.dev/fungible", // TODO fill with real url once doc is live
+        },
+        description: "A fungible asset minting dapp",
       },
     ],
     initial: 0,


### PR DESCRIPTION
With the latest contract changes https://github.com/aptos-labs/create-aptos-dapp/pull/95 , we update the wizard tool to show next steps as

```
Success! You're ready to start building your dapp on Aptos.

Next steps:

1. cd ${projectName}
2. npm run dev
3. Follow the instructions for the ${selection.template.name} template on ${selection.template.doc}
```

In addition, we write the `VITE_CREATOR_ADDRESS=""` to the project `.env` file so later the developer can update it with the account address