### PR TITLE
Refactors create collection form for digital

### DIFF
--- a/templates/digital-asset-template/frontend/components/ui/alert-dialog.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/templates/digital-asset-template/frontend/components/ui/button.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/button.tsx
@@ -16,6 +16,8 @@ const buttonVariants = cva(
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        green:
+          "focus:outline-none text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         icon: "border bg-background hover:bg-accent hover:text-accent-foreground",

--- a/templates/digital-asset-template/frontend/components/ui/confirm-button.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/confirm-button.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+import { Button } from "./button";
+
+export const ConfirmButton: FC<{
+  title: string;
+  disabled?: boolean;
+  onSubmit: () => void;
+  confirmMessage: React.ReactNode;
+}> = ({ onSubmit, disabled, title, confirmMessage }) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="green" disabled={disabled}>
+          {title}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirm</AlertDialogTitle>
+          <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+            {confirmMessage}
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onSubmit}>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/templates/digital-asset-template/frontend/components/ui/date-time-input.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/date-time-input.tsx
@@ -1,0 +1,76 @@
+import { SelectSingleEventHandler } from "react-day-picker";
+import { format } from "date-fns";
+import { Label } from "./label";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { cn } from "@/lib/utils";
+import { CalendarIcon } from "lucide-react";
+import { FC } from "react";
+import { Calendar } from "./calendar";
+import { Input } from "./input";
+import { Button } from "./button";
+
+export const DateTimeInput: FC<{
+  className?: string;
+  label: string;
+  required?: boolean;
+  tooltip: string;
+  disabled?: boolean;
+  date?: Date;
+  onDateChange: SelectSingleEventHandler;
+  time?: string;
+  onTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  id: string;
+}> = ({
+  className,
+  id,
+  tooltip,
+  label,
+  disabled,
+  date,
+  onDateChange,
+  time,
+  onTimeChange,
+}) => {
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      <Label htmlFor={id} tooltip={tooltip}>
+        {label}
+      </Label>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            disabled={disabled}
+            id={id}
+            variant="outline"
+            className={cn(
+              "justify-start text-left font-normal",
+              !date && "text-muted-foreground"
+            )}>
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date ? (
+              format(date, "MM/dd/yyyy hh:mm a")
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto">
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={onDateChange}
+            initialFocus
+            footer={
+              <Input
+                type="time"
+                className="w-max py-6"
+                value={time}
+                onChange={onTimeChange}
+              />
+            }
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};

--- a/templates/digital-asset-template/frontend/components/ui/input.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/input.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  webkitdirectory?: "true" | "false";
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/templates/digital-asset-template/frontend/components/ui/labeled-input.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/labeled-input.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FC } from "react";
+
+export const LabeledInput: FC<{
+  label: string;
+  required?: boolean;
+  tooltip: string;
+  disabled?: boolean;
+  value?: number | string;
+  type?: "number" | "text";
+  id: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}> = ({
+  label,
+  required,
+  tooltip,
+  disabled,
+  value,
+  onChange,
+  id,
+  type = "number",
+}) => {
+  return (
+    <div className="flex flex-col item-center space-y-4">
+      <Label htmlFor={id} tooltip={tooltip}>
+        {label} {required ? "" : "(optional)"}
+      </Label>
+      <Input
+        disabled={disabled}
+        type={type}
+        id={id}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
+++ b/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -7,20 +7,8 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { Calendar as CalendarIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import {
-  InputTransactionData,
-  useWallet,
-} from "@aptos-labs/wallet-adapter-react";
+import { useRef, useState } from "react";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { aptosClient } from "@/utils/aptosClient";
 import { uploadCollectionData } from "@/utils/assetsUploader";
 import {
@@ -34,6 +22,9 @@ import { LaunchpadHeader } from "@/components/LaunchpadHeader";
 import { CREATOR_ADDRESS } from "@/constants";
 import { WarningAlert } from "@/components/ui/warning-alert";
 import { UploadSpinner } from "@/components/UploadSpinner";
+import { LabeledInput } from "../components/ui/labeled-input";
+import { DateTimeInput } from "@/components/ui/date-time-input";
+import { ConfirmButton } from "@/components/ui/confirm-button";
 
 export function CreateCollection() {
   // Wallet connect providers
@@ -53,27 +44,10 @@ export function CreateCollection() {
   const [publicMintEndTime, setPublicMintEndTime] = useState<string>();
   const [mintLimitPerAccount, setMintLimitPerAccount] = useState<number>();
   const [mintFeePerNFT, setMintFeePerNFT] = useState<number>();
-  const [isUploading, setIsUploading] = useState<boolean>(false);
-
-  // Collection data from collection metadata upload by the user
-  const [maxSupply, setMaxSupply] = useState<number>();
-  const [collectionName, setCollectionName] = useState<string>();
-  const [collectionDescription, setCollectionDescription] = useState<string>();
-  const [projectUri, setProjectUri] = useState<string>();
-
-  // UI internal state
-  const [uploadStatus, setUploadStatus] = useState(
-    "Uploads collection files to Irys, a decentralized storage"
-  );
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    // So we can upload a folder
-    if (inputRef.current) {
-      inputRef.current.setAttribute("webkitdirectory", "true");
-    }
-  }, []);
 
   const onPublicMintStartTime = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -101,75 +75,60 @@ export function CreateCollection() {
     setPublicMintEndDate(publicMintEndDate);
   };
 
-  // Function to upload Collection data to Irys - a decentralized asset server
-  const onUploadFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const createCollection = async () => {
     try {
-      if (event.target.files) {
-        setIsUploading(true);
-        const files = event.target.files;
-        alert(`The upload process requires at least 2 message signatures
-        1. To upload collection cover image file and NFT image files into Irys
-        2. To upload collection metadata file and NFT metadata files into Irys
+      if (!account) throw new Error("Please connect your wallet");
+      if (!files) throw new Error("Please upload files");
+      if (account.address !== CREATOR_ADDRESS) throw new Error("Wrong account");
+      if (isUploading) throw new Error("Uploading in progress");
 
-        In the case we need to fund a node on Irys, a transfer transaction submission is required also.`);
-        await uploadCollectionData(
-          aptosWallet,
-          files,
-          setCollectionName,
-          setCollectionDescription,
-          setMaxSupply,
-          setProjectUri,
-          setUploadStatus
-        );
+      setIsUploading(true);
+
+      const { collectionName, collectionDescription, maxSupply, projectUri } =
+        await uploadCollectionData(aptosWallet, files);
+
+      const response = await signAndSubmitTransaction({
+        data: {
+          function: `${
+            import.meta.env.VITE_MODULE_ADDRESS
+          }::launchpad::create_collection`,
+          typeArguments: [],
+          functionArguments: [
+            collectionDescription,
+            collectionName,
+            projectUri,
+            maxSupply,
+            royaltyPercentage,
+            preMintAmount, // amount of NFT to premint for myself
+            undefined, // addresses in the allow list
+            undefined, // allow list start time (in seconds)
+            undefined, // allow list end time (in seconds)
+            undefined, // mint limit per address in the allow list
+            undefined, // mint fee per NFT for the allow list
+            dateToSeconds(publicMintStartDate), // public mint start time (in seconds)
+            dateToSeconds(publicMintEndDate), // public mint end time (in seconds)
+            mintLimitPerAccount, // mint limit per address in the public mint
+            mintFeePerNFT
+              ? convertAmountFromHumanReadableToOnChain(
+                  mintFeePerNFT,
+                  APT_DECIMALS
+                )
+              : 0, // mint fee per NFT for the public mint, on chain stored in smallest unit of APT (i.e. 1e8 oAPT = 1 APT)
+          ],
+        },
+      });
+
+      const committedTransactionResponse =
+        await aptosClient().waitForTransaction({
+          transactionHash: response.hash,
+        });
+      if (committedTransactionResponse.success) {
+        navigate(`/my-collections`, { replace: true });
       }
+    } catch (error) {
+      alert(error);
     } finally {
       setIsUploading(false);
-    }
-  };
-
-  const createCollection = async () => {
-    if (!account) return;
-
-    const transaction: InputTransactionData = {
-      data: {
-        function: `${
-          import.meta.env.VITE_MODULE_ADDRESS
-        }::launchpad::create_collection`,
-        typeArguments: [],
-        functionArguments: [
-          collectionDescription,
-          collectionName,
-          projectUri,
-          maxSupply,
-          royaltyPercentage,
-          preMintAmount, // amount of NFT to premint for myself
-          undefined, // addresses in the allow list
-          undefined, // allow list start time (in seconds)
-          undefined, // allow list end time (in seconds)
-          undefined, // mint limit per address in the allow list
-          undefined, // mint fee per NFT for the allow list
-          dateToSeconds(publicMintStartDate), // public mint start time (in seconds)
-          dateToSeconds(publicMintEndDate), // public mint end time (in seconds)
-          mintLimitPerAccount, // mint limit per address in the public mint
-          mintFeePerNFT
-            ? convertAmountFromHumanReadableToOnChain(
-                mintFeePerNFT,
-                APT_DECIMALS
-              )
-            : 0, // mint fee per NFT for the public mint, on chain stored in smallest unit of APT (i.e. 1e8 oAPT = 1 APT)
-        ],
-      },
-    };
-
-    const response = await signAndSubmitTransaction(transaction);
-
-    const committedTransactionResponse = await aptosClient().waitForTransaction(
-      {
-        transactionHash: response.hash,
-      }
-    );
-    if (committedTransactionResponse.success) {
-      navigate(`/my-collections`, { replace: true });
     }
   };
 
@@ -196,207 +155,159 @@ export function CreateCollection() {
 
           <UploadSpinner on={isUploading} />
 
-          <h3 className="font-bold leading-none tracking-tight md:text-xl dark:text-white py-2">
-            Create NFT Collection
-          </h3>
-          <div className="py-2">
-            <div className="mb-5 flex flex-col item-center space-y-4">
-              <Card>
-                <CardHeader>
-                  <CardDescription>{uploadStatus}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex flex-col items-center justify-between">
-                    <Input
-                      disabled={isUploading || !account}
-                      ref={inputRef}
-                      multiple
-                      type="file"
-                      placeholder="Upload Assets"
-                      onChange={(event) => onUploadFile(event)}
-                    />
+          <h3 className="display">Create NFT Collection</h3>
+
+          <Card>
+            <CardHeader>
+              <CardDescription>
+                Uploads collection files to Irys, a decentralized storage
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col items-start justify-between">
+                {!files?.length && (
+                  <Label
+                    htmlFor="upload"
+                    className={buttonVariants({
+                      variant: "outline",
+                      className: "cursor-pointer",
+                    })}
+                  >
+                    Choose Files to Upload
+                  </Label>
+                )}
+                <Input
+                  className="hidden"
+                  ref={inputRef}
+                  id="upload"
+                  disabled={isUploading || !account}
+                  webkitdirectory="true"
+                  multiple
+                  type="file"
+                  placeholder="Upload Assets"
+                  onChange={(event) => {
+                    setFiles(event.currentTarget.files);
+                  }}
+                />
+
+                {!!files?.length && (
+                  <div>
+                    {files.length} files selected{" "}
+                    <Button
+                      variant="link"
+                      className="text-destructive"
+                      onClick={() => {
+                        setFiles(null);
+                        inputRef.current!.value = "";
+                      }}
+                    >
+                      Clear
+                    </Button>
                   </div>
-                </CardContent>
-              </Card>
-            </div>
-
-            <div className="mb-5 flex flex-col item-center space-y-4">
-              <div className="flex flex-row space-between">
-                <div className="flex flex-col mr-4">
-                  <Label
-                    htmlFor="mint-start"
-                    tooltip="When minting becomes active"
-                    className="mb-4"
-                  >
-                    Public mint start date
-                  </Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        disabled={isUploading || !account}
-                        id="mint-start"
-                        variant={"outline"}
-                        className={cn(
-                          "w-[280px] justify-start text-left font-normal",
-                          !publicMintStartDate && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {publicMintStartDate ? (
-                          format(publicMintStartDate, "MM/dd/yyyy hh:mm a")
-                        ) : (
-                          <span>Pick a date</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0">
-                      <Calendar
-                        mode="single"
-                        selected={publicMintStartDate}
-                        onSelect={setPublicMintStartDate}
-                        initialFocus
-                        footer={
-                          <Input
-                            type="time"
-                            className="w-max py-6"
-                            value={publicMintStartTime}
-                            onChange={(event) => onPublicMintStartTime(event)}
-                          />
-                        }
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
-
-                <div className="flex flex-col">
-                  <Label
-                    htmlFor="mint-end"
-                    tooltip="When minting finishes."
-                    className="mb-4"
-                  >
-                    Public mint end date
-                  </Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        disabled={isUploading || !account}
-                        id="mint-end"
-                        variant={"outline"}
-                        className={cn(
-                          "w-[280px] justify-start text-left font-normal",
-                          !publicMintEndDate && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {publicMintEndDate ? (
-                          format(publicMintEndDate, "MM/dd/yyyy hh:mm a")
-                        ) : (
-                          <span>Pick a date</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0">
-                      <Calendar
-                        mode="single"
-                        selected={publicMintEndDate}
-                        onSelect={setPublicMintEndDate}
-                        initialFocus
-                        footer={
-                          <Input
-                            type="time"
-                            className="w-max py-6"
-                            value={publicMintEndTime}
-                            onChange={(event) => onPublicMintEndTime(event)}
-                          />
-                        }
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
+                )}
               </div>
-            </div>
-          </div>
-          <div className="mb-5 flex flex-col item-center space-y-4">
-            <Label
-              htmlFor="mint-limit"
-              tooltip="How many NFTs an individual address is allowed to mint."
-            >
-              Limit mint per address
-            </Label>
-            <Input
+            </CardContent>
+          </Card>
+
+          <div className="flex item-center gap-4">
+            <DateTimeInput
+              id="mint-start"
+              label="Public mint start date"
+              tooltip="When minting becomes active"
               disabled={isUploading || !account}
-              id="mint-limit"
-              type="number"
-              value={mintLimitPerAccount}
-              onChange={(e) => {
-                setMintLimitPerAccount(parseInt(e.target.value));
-              }}
+              date={publicMintStartDate}
+              onDateChange={setPublicMintStartDate}
+              time={publicMintStartTime}
+              onTimeChange={onPublicMintStartTime}
+              className="basis-1/2"
+            />
+
+            <DateTimeInput
+              id="mint-end"
+              label="Public mint end date"
+              tooltip="When minting finishes"
+              disabled={isUploading || !account}
+              date={publicMintEndDate}
+              onDateChange={setPublicMintEndDate}
+              time={publicMintEndTime}
+              onTimeChange={onPublicMintEndTime}
+              className="basis-1/2"
             />
           </div>
-          <div className="mb-5 flex flex-col item-center space-y-4">
-            <Label
-              tooltip="The percentage of trading value that collection creator gets when an NFT is sold on marketplaces."
-              htmlFor="royalty-percentage"
-            >
-              Royalty Percentage (optional)
-            </Label>
-            <Input
-              disabled={isUploading || !account}
-              id="royalty-percentage"
-              type="number"
-              onChange={(e) => {
-                setRoyaltyPercentage(e.target.value);
-              }}
-            />
-          </div>
-          <div className="mb-5 flex flex-col item-center space-y-4">
-            <Label
-              htmlFor="mint-fee"
-              tooltip="The fee the nft minter is paying the collection creator when they mint an NFT"
-            >
-              Mint fee per NFT in APT (optional)
-            </Label>
-            <Input
-              disabled={isUploading || !account}
-              type="number"
-              id="mint-fee"
-              value={mintFeePerNFT}
-              onChange={(e) => {
-                setMintFeePerNFT(parseFloat(e.target.value));
-              }}
-            />
-          </div>
-          <div className="mb-5 flex flex-col item-center space-y-4">
-            <Label
-              htmlFor="for-myself"
-              tooltip="How many NFTs to mint immediately for the creator."
-            >
-              Mint for myself (optional)
-            </Label>
-            <Input
-              disabled={isUploading || !account}
-              type="number"
-              id="for-myself"
-              value={preMintAmount}
-              onChange={(e) => {
-                setPreMintAmount(e.target.value);
-              }}
-            />
-          </div>
-          <Button
+
+          <LabeledInput
+            id="mint-limit"
+            required
+            label="Mint limit per address"
+            tooltip="How many NFTs an individual address is allowed to mint"
+            disabled={isUploading || !account}
+            onChange={(e) => {
+              setMintLimitPerAccount(parseInt(e.target.value));
+            }}
+          />
+
+          <LabeledInput
+            id="royalty-percentage"
+            label="Royalty Percentage"
+            tooltip="The percentage of trading value that collection creator gets when an NFT is sold on marketplaces"
+            disabled={isUploading || !account}
+            onChange={(e) => {
+              setRoyaltyPercentage(e.target.value);
+            }}
+          />
+
+          <LabeledInput
+            id="mint-fee"
+            label="Mint fee per NFT in APT"
+            tooltip="The fee the nft minter is paying the collection creator when they mint an NFT"
+            disabled={isUploading || !account}
+            onChange={(e) => {
+              setMintFeePerNFT(parseInt(e.target.value));
+            }}
+          />
+
+          <LabeledInput
+            id="for-myself"
+            label="Mint for myself"
+            tooltip="How many NFTs to mint immediately for the creator"
+            disabled={isUploading || !account}
+            onChange={(e) => {
+              setPreMintAmount(e.target.value);
+            }}
+          />
+
+          <ConfirmButton
+            title="Create Collection"
+            onSubmit={createCollection}
             disabled={
-              !maxSupply ||
               !account ||
+              !files?.length ||
               !publicMintStartDate ||
               !mintLimitPerAccount ||
               !account ||
               isUploading
             }
-            className="focus:outline-none text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800"
-            onClick={createCollection}
-          >
-            Create Collection
-          </Button>
+            confirmMessage={
+              <>
+                <p>The upload process requires at least 2 message signatures</p>
+                <ol className="list-decimal list-inside">
+                  <li>
+                    To upload collection cover image file and NFT image files
+                    into Irys.
+                  </li>
+
+                  <li>
+                    To upload collection metadata file and NFT metadata files
+                    into Irys.
+                  </li>
+                </ol>
+                <p>
+                  In the case we need to fund a node on Irys, a transfer
+                  transaction submission is required also.
+                </p>
+              </>
+            }
+          />
         </div>
       </div>
     </>

--- a/templates/digital-asset-template/frontend/utils/Irys.ts
+++ b/templates/digital-asset-template/frontend/utils/Irys.ts
@@ -45,9 +45,9 @@ export const checkIfFund = async (
     try {
       await fundNode(aptosWallet, costToUpload.toNumber());
       return true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      alert(`Error funding node ${error}`);
-      return;
+      throw new Error(`Error funding node ${error}`);
     }
   }
   // 6. if payer balance < the amount, replenish the payer balance*/
@@ -69,12 +69,12 @@ export const fundNode = async (
     );
     return true;
   } catch (e) {
-    console.log("Error uploading data ", e);
-    return false;
+    throw new Error(`Error uploading data ${e}`);
   }
 };
 
 export const uploadFile = async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   aptosWallet: any,
   fileToUpload: File
 ): Promise<string> => {
@@ -82,9 +82,9 @@ export const uploadFile = async (
   try {
     const receipt = await webIrys.uploadFile(fileToUpload, { tags: [] });
     return `https://gateway.irys.xyz/${receipt.id}`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
-    console.log("Error uploading file ", e);
-    throw new Error(e);
+    throw new Error(`Error uploading file ${e}`);
   }
 };
 
@@ -98,12 +98,12 @@ export const uploadFolder = async (
     const receipt = await webIrys.uploadFolder(files); //returns the manifest ID
 
     console.log(
-      `Files uploaded. Manifest Id=${receipt.manifestId} Receipt Id=${receipt.id} 
+      `Files uploaded. Manifest Id=${receipt.manifestId} Receipt Id=${receipt.id}
       access with: https://gateway.irys.xyz/${receipt.manifestId}/<image-name>`
     );
     return `https://gateway.irys.xyz/${receipt.manifestId}`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
-    console.log("Error uploading folder ", e);
-    throw new Error(e);
+    throw new Error(`Error uploading folder ${e}`);
   }
 };

--- a/templates/digital-asset-template/package.json
+++ b/templates/digital-asset-template/package.json
@@ -18,6 +18,7 @@
     "@aptos-labs/wallet-adapter-react": "^3.3.0",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/templates/fungible-asset-template/frontend/components/ui/alert-dialog.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/templates/fungible-asset-template/frontend/components/ui/button.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/button.tsx
@@ -16,6 +16,8 @@ const buttonVariants = cva(
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        green:
+          "focus:outline-none text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         icon: "border bg-background hover:bg-accent hover:text-accent-foreground",

--- a/templates/fungible-asset-template/frontend/components/ui/confirm-button.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/confirm-button.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+import { Button } from "./button";
+
+export const ConfirmButton: FC<{
+  title: string;
+  disabled?: boolean;
+  onSubmit: () => void;
+  confirmMessage: React.ReactNode;
+}> = ({ onSubmit, disabled, title, confirmMessage }) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="green" disabled={disabled}>
+          {title}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirm</AlertDialogTitle>
+          <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+            {confirmMessage}
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onSubmit}>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/templates/fungible-asset-template/frontend/components/ui/date-time-input.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/date-time-input.tsx
@@ -1,0 +1,76 @@
+import { SelectSingleEventHandler } from "react-day-picker";
+import { format } from "date-fns";
+import { Label } from "./label";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { cn } from "@/lib/utils";
+import { CalendarIcon } from "lucide-react";
+import { FC } from "react";
+import { Calendar } from "./calendar";
+import { Input } from "./input";
+import { Button } from "./button";
+
+export const DateTimeInput: FC<{
+  className?: string;
+  title: string;
+  required?: boolean;
+  tooltip: string;
+  disabled?: boolean;
+  date?: Date;
+  onDateChange: SelectSingleEventHandler;
+  time?: string;
+  onTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  id: string;
+}> = ({
+  className,
+  id,
+  tooltip,
+  title,
+  disabled,
+  date,
+  onDateChange,
+  time,
+  onTimeChange,
+}) => {
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      <Label htmlFor={id} tooltip={tooltip}>
+        {title}
+      </Label>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            disabled={disabled}
+            id={id}
+            variant="outline"
+            className={cn(
+              "justify-start text-left font-normal",
+              !date && "text-muted-foreground"
+            )}>
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date ? (
+              format(date, "MM/dd/yyyy hh:mm a")
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto">
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={onDateChange}
+            initialFocus
+            footer={
+              <Input
+                type="time"
+                className="w-max py-6"
+                value={time}
+                onChange={onTimeChange}
+              />
+            }
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};

--- a/templates/fungible-asset-template/frontend/components/ui/labeled-input.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/labeled-input.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FC } from "react";
+
+export const LabeledInput: FC<{
+  label: string;
+  required?: boolean;
+  tooltip: string;
+  disabled?: boolean;
+  value?: number | string;
+  type?: "number" | "text";
+  id: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}> = ({
+  label,
+  required,
+  tooltip,
+  disabled,
+  value,
+  onChange,
+  id,
+  type = "number",
+}) => {
+  return (
+    <div className="flex flex-col item-center space-y-4">
+      <Label htmlFor={id} tooltip={tooltip}>
+        {label} {required ? "" : "(optional)"}
+      </Label>
+      <Input
+        disabled={disabled}
+        type={type}
+        id={id}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/templates/fungible-asset-template/frontend/utils/Irys.ts
+++ b/templates/fungible-asset-template/frontend/utils/Irys.ts
@@ -2,6 +2,7 @@ import { WebIrys } from "@irys/sdk";
 import { WalletContextState } from "@aptos-labs/wallet-adapter-react";
 import { aptosClient } from "./aptosClient";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getWebIrys = async (aptosWallet: any) => {
   const network = "devnet"; // Irys network
   const token = "aptos";
@@ -68,8 +69,7 @@ export const fundNode = async (
     );
     return true;
   } catch (e) {
-    console.log("Error uploading data ", e);
-    return false;
+    throw new Error(`Error uploading data ${e}`);
   }
 };
 
@@ -82,8 +82,7 @@ export const uploadFile = async (
     const receipt = await webIrys.uploadFile(fileToUpload, { tags: [] });
     return `https://gateway.irys.xyz/${receipt.id}`;
   } catch (e) {
-    console.log("Error uploading file ", e);
-    return "";
+    throw new Error(`Error uploading file ${e}`);
   }
 };
 
@@ -97,10 +96,10 @@ export const uploadFolder = async (
     const receipt = await webIrys.uploadFolder(files); //returns the manifest ID
 
     console.log(
-      `Files uploaded. Manifest Id=${receipt.manifestId} Receipt Id=${receipt.id} 
+      `Files uploaded. Manifest Id=${receipt.manifestId} Receipt Id=${receipt.id}
       access with: https://gateway.irys.xyz/${receipt.manifestId}/<image-name>`
     );
   } catch (e) {
-    console.log("Error uploading file ", e);
+    throw new Error(`Error uploading folder ${e}`);
   }
 };

--- a/templates/fungible-asset-template/frontend/utils/Irys.ts
+++ b/templates/fungible-asset-template/frontend/utils/Irys.ts
@@ -47,8 +47,13 @@ export const checkIfFund = async (
 
   // 5. if payer balance > the amount based on the estimation, fund the irys node irys.fund, then upload
   if (currentAccountBalance[0] > costToUpload.toNumber()) {
-    await fundNode(aptosWallet, costToUpload.toNumber());
-    return true;
+    try {
+      await fundNode(aptosWallet, costToUpload.toNumber());
+      return true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      throw new Error(`Error funding node ${error}`);
+    }
   }
   // 6. if payer balance < the amount, replenish the payer balance*/
   return false;
@@ -83,23 +88,5 @@ export const uploadFile = async (
     return `https://gateway.irys.xyz/${receipt.id}`;
   } catch (e) {
     throw new Error(`Error uploading file ${e}`);
-  }
-};
-
-export const uploadFolder = async (
-  aptosWallet: WalletContextState,
-  files: File[]
-) => {
-  const webIrys = await getWebIrys(aptosWallet);
-
-  try {
-    const receipt = await webIrys.uploadFolder(files); //returns the manifest ID
-
-    console.log(
-      `Files uploaded. Manifest Id=${receipt.manifestId} Receipt Id=${receipt.id}
-      access with: https://gateway.irys.xyz/${receipt.manifestId}/<image-name>`
-    );
-  } catch (e) {
-    throw new Error(`Error uploading folder ${e}`);
   }
 };

--- a/templates/fungible-asset-template/package.json
+++ b/templates/fungible-asset-template/package.json
@@ -18,6 +18,7 @@
     "@aptos-labs/wallet-adapter-react": "^3.3.0",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/templates/fungible-asset-template/package.json
+++ b/templates/fungible-asset-template/package.json
@@ -33,6 +33,7 @@
     "@tanstack/react-query": "^5.45.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
     "lucide-react": "^0.383.0",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",


### PR DESCRIPTION
This PR refactors the create collection screen for digital assets a bit to fix a few of our issues:

- If uploading a collection fails, you need to first clear it (which will trigger messages) and then re-select the collection
-  "decentrelized" is spelled wrong
- Using `alert` to communicate with the user when creating a collection is not great UX

~Note, I will go through the fungible flow as well after this PR lands or gets changed based on feedback.~

Both flows are now updated. 

https://github.com/aptos-labs/create-aptos-dapp/assets/694324/a90777d5-3fb5-4695-b894-ca5463d14b7a


~https://github.com/aptos-labs/create-aptos-dapp/assets/694324/78a03985-3005-4683-bced-18ca8d40e056~
