### PR TITLE
Support dark mode + minor UI cleanup

### DIFF
--- a/templates/digital-asset-template/frontend/components/WalletProvider.tsx
+++ b/templates/digital-asset-template/frontend/components/WalletProvider.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from "react";
+import { useToast } from "./ui/use-toast";
+import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
+
+export function WalletProvider({ children }: PropsWithChildren) {
+  const { toast } = useToast();
+
+  return (
+    <AptosWalletAdapterProvider
+      autoConnect={true}
+      onError={(error) => {
+        toast({
+          variant: "destructive",
+          title: "Error",
+          description: error || "Unknown wallet error",
+        });
+      }}
+    >
+      {children}
+    </AptosWalletAdapterProvider>
+  );
+}

--- a/templates/digital-asset-template/frontend/components/WalletSelector.tsx
+++ b/templates/digital-asset-template/frontend/components/WalletSelector.tsx
@@ -1,12 +1,15 @@
 import {
+  APTOS_CONNECT_ACCOUNT_URL,
   AnyAptosWallet,
   WalletItem,
+  getAptosConnectWallets,
+  isAptosConnectWallet,
   isInstallRequired,
   partitionWallets,
   truncateAddress,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import { ChevronDown, Copy, LogOut } from "lucide-react";
+import { ChevronDown, Copy, LogOut, User } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Button } from "./ui/button";
 import {
@@ -30,7 +33,7 @@ import {
 import { useToast } from "./ui/use-toast";
 
 export function WalletSelector() {
-  const { disconnect, account, connected } = useWallet();
+  const { account, connected, disconnect, wallet } = useWallet();
   const { toast } = useToast();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -64,6 +67,18 @@ export function WalletSelector() {
         <DropdownMenuItem onSelect={copyAddress} className="gap-2">
           <Copy className="h-4 w-4" /> Copy address
         </DropdownMenuItem>
+        {wallet && isAptosConnectWallet(wallet) && (
+          <DropdownMenuItem asChild>
+            <a
+              href={APTOS_CONNECT_ACCOUNT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex gap-2"
+            >
+              <User className="h-4 w-4" /> Account
+            </a>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onSelect={disconnect} className="gap-2">
           <LogOut className="h-4 w-4" /> Disconnect
         </DropdownMenuItem>
@@ -84,33 +99,67 @@ interface ConnectWalletDialogProps {
 }
 
 function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
-  const { wallets } = useWallet();
-  const { defaultWallets, moreWallets } = partitionWallets(wallets ?? []);
+  const { wallets = [] } = useWallet();
+
+  const {
+    /** Wallets that use social login to create an account on the blockchain */
+    aptosConnectWallets,
+    /** Wallets that use traditional wallet extensions */
+    otherWallets,
+  } = getAptosConnectWallets(wallets);
+
+  const {
+    /** Wallets that are currently installed or loadable. */
+    defaultWallets,
+    /** Wallets that are NOT currently installed or loadable. */
+    moreWallets,
+  } = partitionWallets(otherWallets);
 
   return (
     <DialogContent className="max-h-screen overflow-auto">
-      <DialogHeader>
-        <DialogTitle>Connect Wallet</DialogTitle>
+      <DialogHeader className="flex flex-col items-center">
+        <DialogTitle className="flex flex-col text-center leading-snug">
+          <span>Log in or sign up</span>
+          <span>with Social + Aptos Connect</span>
+        </DialogTitle>
       </DialogHeader>
+      <div className="flex flex-col gap-3 pt-3">
+        {aptosConnectWallets.map((wallet) => (
+          <AptosConnectWalletRow
+            key={wallet.name}
+            wallet={wallet}
+            onConnect={close}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-3 pt-4 text-muted-foreground">
+        <div className="h-px w-full bg-secondary" />
+        Or
+        <div className="h-px w-full bg-secondary" />
+      </div>
       <div className="flex flex-col gap-3 pt-3">
         {defaultWallets.map((wallet) => (
           <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
         ))}
+        {!!moreWallets.length && (
+          <Collapsible className="flex flex-col gap-3">
+            <CollapsibleTrigger asChild>
+              <Button size="sm" variant="ghost" className="gap-2">
+                More wallets <ChevronDown />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="flex flex-col gap-3">
+              {moreWallets.map((wallet) => (
+                <WalletRow
+                  key={wallet.name}
+                  wallet={wallet}
+                  onConnect={close}
+                />
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       </div>
-      {!!moreWallets.length && (
-        <Collapsible className="flex flex-col gap-4">
-          <CollapsibleTrigger asChild>
-            <Button size="sm" variant="ghost" className="gap-2">
-              More wallets <ChevronDown />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="flex flex-col gap-3">
-            {moreWallets.map((wallet) => (
-              <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            ))}
-          </CollapsibleContent>
-        </Collapsible>
-      )}
     </DialogContent>
   );
 }
@@ -140,6 +189,19 @@ function WalletRow({ wallet, onConnect }: WalletRowProps) {
           <Button size="sm">Connect</Button>
         </WalletItem.ConnectButton>
       )}
+    </WalletItem>
+  );
+}
+
+function AptosConnectWalletRow({ wallet, onConnect }: WalletRowProps) {
+  return (
+    <WalletItem wallet={wallet} onConnect={onConnect}>
+      <WalletItem.ConnectButton asChild>
+        <Button size="lg" variant="outline" className="w-full gap-4">
+          <WalletItem.Icon className="h-5 w-5" />
+          <WalletItem.Name className="text-base font-normal" />
+        </Button>
+      </WalletItem.ConnectButton>
     </WalletItem>
   );
 }

--- a/templates/digital-asset-template/frontend/components/ui/input.tsx
+++ b/templates/digital-asset-template/frontend/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-primary file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/templates/digital-asset-template/frontend/main.tsx
+++ b/templates/digital-asset-template/frontend/main.tsx
@@ -1,32 +1,25 @@
+import "./index.css";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
 
 import App from "./App";
-
-// CSS files
-import "./index.css";
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
+import { WalletProvider } from "./components/WalletProvider";
+import { Toaster } from "./components/ui/toaster";
 import { TooltipProvider } from "./components/ui/tooltip";
 
 const queryClient = new QueryClient();
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
-root.render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <AptosWalletAdapterProvider
-      autoConnect={true}
-      onError={(error) => {
-        console.log(error);
-      }}>
+    <WalletProvider>
       <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
+        <TooltipProvider delayDuration={100}>
           <App />
+          <Toaster />
         </TooltipProvider>
       </QueryClientProvider>
-    </AptosWalletAdapterProvider>
+    </WalletProvider>
   </React.StrictMode>
 );

--- a/templates/digital-asset-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/digital-asset-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -159,7 +159,7 @@ const AddressButton: FC<{ address: string }> = ({ address }) => {
       ) : (
         <>
           {truncateAddress(address)}
-          <Image src={Copy} />
+          <Image src={Copy} className="dark:invert" />
         </>
       )}
     </Button>

--- a/templates/digital-asset-template/frontend/pages/Mint/components/OurTeamSection.tsx
+++ b/templates/digital-asset-template/frontend/pages/Mint/components/OurTeamSection.tsx
@@ -41,12 +41,22 @@ const TeamCard: FC<{ member: ConfigTeamMember }> = ({ member }) => {
           {member.name}
           {member.socials?.twitter && (
             <a target="_blank" href={member.socials.twitter}>
-              <Image width={16} height={16} src={Twitter} />
+              <Image
+                width={16}
+                height={16}
+                src={Twitter}
+                className="dark:invert"
+              />
             </a>
           )}
           {member.socials?.discord && (
             <a target="_blank" href={member.socials.discord}>
-              <Image width={16} height={16} src={Discord} />
+              <Image
+                width={16}
+                height={16}
+                src={Discord}
+                className="dark:invert"
+              />
             </a>
           )}
         </CardTitle>

--- a/templates/digital-asset-template/frontend/pages/Mint/components/Socials.tsx
+++ b/templates/digital-asset-template/frontend/pages/Mint/components/Socials.tsx
@@ -17,7 +17,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.twitter}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Twitter} />
+            <Image src={Twitter} className="dark:invert" />
           </a>
         </li>
       )}
@@ -27,7 +27,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.discord}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Discord} />
+            <Image src={Discord} className="dark:invert" />
           </a>
         </li>
       )}
@@ -37,7 +37,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.homepage}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Link} />
+            <Image src={Link} className="dark:invert" />
           </a>
         </li>
       )}

--- a/templates/digital-asset-template/frontend/pages/Mint/index.tsx
+++ b/templates/digital-asset-template/frontend/pages/Mint/index.tsx
@@ -1,4 +1,3 @@
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 import { BannerSection } from "./components/BannerSection";
 import { HeroSection } from "./components/HeroSection";
 import { StatsSection } from "./components/StatsSection";

--- a/templates/digital-asset-template/package.json
+++ b/templates/digital-asset-template/package.json
@@ -15,9 +15,7 @@
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "1.19.0",
-    "@aptos-labs/wallet-adapter-ant-design": "^2.4.5",
-    "@aptos-labs/wallet-adapter-react": "^3.1.0",
-    "@identity-connect/wallet-adapter-plugin": "^1.2.5",
+    "@aptos-labs/wallet-adapter-react": "^3.3.0",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.0.3",

--- a/templates/fungible-asset-template/frontend/components/WalletProvider.tsx
+++ b/templates/fungible-asset-template/frontend/components/WalletProvider.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from "react";
+import { useToast } from "./ui/use-toast";
+import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
+
+export function WalletProvider({ children }: PropsWithChildren) {
+  const { toast } = useToast();
+
+  return (
+    <AptosWalletAdapterProvider
+      autoConnect={true}
+      onError={(error) => {
+        toast({
+          variant: "destructive",
+          title: "Error",
+          description: error || "Unknown wallet error",
+        });
+      }}
+    >
+      {children}
+    </AptosWalletAdapterProvider>
+  );
+}

--- a/templates/fungible-asset-template/frontend/components/WalletSelector.tsx
+++ b/templates/fungible-asset-template/frontend/components/WalletSelector.tsx
@@ -1,12 +1,15 @@
 import {
+  APTOS_CONNECT_ACCOUNT_URL,
   AnyAptosWallet,
   WalletItem,
+  getAptosConnectWallets,
+  isAptosConnectWallet,
   isInstallRequired,
   partitionWallets,
   truncateAddress,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import { ChevronDown, Copy, LogOut } from "lucide-react";
+import { ChevronDown, Copy, LogOut, User } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Button } from "./ui/button";
 import {
@@ -30,7 +33,7 @@ import {
 import { useToast } from "./ui/use-toast";
 
 export function WalletSelector() {
-  const { disconnect, account, connected } = useWallet();
+  const { account, connected, disconnect, wallet } = useWallet();
   const { toast } = useToast();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -64,6 +67,18 @@ export function WalletSelector() {
         <DropdownMenuItem onSelect={copyAddress} className="gap-2">
           <Copy className="h-4 w-4" /> Copy address
         </DropdownMenuItem>
+        {wallet && isAptosConnectWallet(wallet) && (
+          <DropdownMenuItem asChild>
+            <a
+              href={APTOS_CONNECT_ACCOUNT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex gap-2"
+            >
+              <User className="h-4 w-4" /> Account
+            </a>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onSelect={disconnect} className="gap-2">
           <LogOut className="h-4 w-4" /> Disconnect
         </DropdownMenuItem>
@@ -84,33 +99,67 @@ interface ConnectWalletDialogProps {
 }
 
 function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
-  const { wallets } = useWallet();
-  const { defaultWallets, moreWallets } = partitionWallets(wallets ?? []);
+  const { wallets = [] } = useWallet();
+
+  const {
+    /** Wallets that use social login to create an account on the blockchain */
+    aptosConnectWallets,
+    /** Wallets that use traditional wallet extensions */
+    otherWallets,
+  } = getAptosConnectWallets(wallets);
+
+  const {
+    /** Wallets that are currently installed or loadable. */
+    defaultWallets,
+    /** Wallets that are NOT currently installed or loadable. */
+    moreWallets,
+  } = partitionWallets(otherWallets);
 
   return (
     <DialogContent className="max-h-screen overflow-auto">
-      <DialogHeader>
-        <DialogTitle>Connect Wallet</DialogTitle>
+      <DialogHeader className="flex flex-col items-center">
+        <DialogTitle className="flex flex-col text-center leading-snug">
+          <span>Log in or sign up</span>
+          <span>with Social + Aptos Connect</span>
+        </DialogTitle>
       </DialogHeader>
+      <div className="flex flex-col gap-3 pt-3">
+        {aptosConnectWallets.map((wallet) => (
+          <AptosConnectWalletRow
+            key={wallet.name}
+            wallet={wallet}
+            onConnect={close}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-3 pt-4 text-muted-foreground">
+        <div className="h-px w-full bg-secondary" />
+        Or
+        <div className="h-px w-full bg-secondary" />
+      </div>
       <div className="flex flex-col gap-3 pt-3">
         {defaultWallets.map((wallet) => (
           <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
         ))}
+        {!!moreWallets.length && (
+          <Collapsible className="flex flex-col gap-3">
+            <CollapsibleTrigger asChild>
+              <Button size="sm" variant="ghost" className="gap-2">
+                More wallets <ChevronDown />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="flex flex-col gap-3">
+              {moreWallets.map((wallet) => (
+                <WalletRow
+                  key={wallet.name}
+                  wallet={wallet}
+                  onConnect={close}
+                />
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       </div>
-      {!!moreWallets.length && (
-        <Collapsible className="flex flex-col gap-4">
-          <CollapsibleTrigger asChild>
-            <Button size="sm" variant="ghost" className="gap-2">
-              More wallets <ChevronDown />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="flex flex-col gap-3">
-            {moreWallets.map((wallet) => (
-              <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            ))}
-          </CollapsibleContent>
-        </Collapsible>
-      )}
     </DialogContent>
   );
 }
@@ -140,6 +189,19 @@ function WalletRow({ wallet, onConnect }: WalletRowProps) {
           <Button size="sm">Connect</Button>
         </WalletItem.ConnectButton>
       )}
+    </WalletItem>
+  );
+}
+
+function AptosConnectWalletRow({ wallet, onConnect }: WalletRowProps) {
+  return (
+    <WalletItem wallet={wallet} onConnect={onConnect}>
+      <WalletItem.ConnectButton asChild>
+        <Button size="lg" variant="outline" className="w-full gap-4">
+          <WalletItem.Icon className="h-5 w-5" />
+          <WalletItem.Name className="text-base font-normal" />
+        </Button>
+      </WalletItem.ConnectButton>
     </WalletItem>
   );
 }

--- a/templates/fungible-asset-template/frontend/components/ui/input.tsx
+++ b/templates/fungible-asset-template/frontend/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-primary file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/templates/fungible-asset-template/frontend/main.tsx
+++ b/templates/fungible-asset-template/frontend/main.tsx
@@ -1,28 +1,25 @@
+import "./index.css";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import App from "./App.tsx";
-
-import "./index.css";
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
+import { Toaster } from "./components/ui/toaster.tsx";
 import { TooltipProvider } from "./components/ui/tooltip.tsx";
+import { WalletProvider } from "./components/WalletProvider.tsx";
 
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <AptosWalletAdapterProvider
-      autoConnect={true}
-      onError={(error) => {
-        console.log("Custom error handling", error);
-      }}>
+    <WalletProvider>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider delayDuration={100}>
           <App />
+          <Toaster />
         </TooltipProvider>
       </QueryClientProvider>
-    </AptosWalletAdapterProvider>
+    </WalletProvider>
   </React.StrictMode>
 );

--- a/templates/fungible-asset-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/fungible-asset-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -146,7 +146,7 @@ const AddressButton: FC<{ address: string }> = ({ address }) => {
       ) : (
         <>
           {truncateAddress(address)}
-          <Image src={Copy} />
+          <Image src={Copy} className="dark:invert" />
         </>
       )}
     </Button>

--- a/templates/fungible-asset-template/frontend/pages/Mint/components/Socials.tsx
+++ b/templates/fungible-asset-template/frontend/pages/Mint/components/Socials.tsx
@@ -17,7 +17,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.twitter}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Twitter} />
+            <Image src={Twitter} className="dark:invert" />
           </a>
         </li>
       )}
@@ -27,7 +27,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.discord}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Discord} />
+            <Image src={Discord} className="dark:invert" />
           </a>
         </li>
       )}
@@ -37,7 +37,7 @@ export const Socials: FC = () => {
             target="_blank"
             href={config.socials.homepage}
             className={buttonVariants({ variant: "icon", size: "icon" })}>
-            <Image src={Link} />
+            <Image src={Link} className="dark:invert" />
           </a>
         </li>
       )}

--- a/templates/fungible-asset-template/frontend/pages/Mint/index.tsx
+++ b/templates/fungible-asset-template/frontend/pages/Mint/index.tsx
@@ -1,4 +1,3 @@
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 import { HeroSection } from "./components/HeroSection";
 import { StatsSection } from "./components/StatsSection";
 import { OurStorySection } from "./components/OurStorySection";

--- a/templates/fungible-asset-template/package.json
+++ b/templates/fungible-asset-template/package.json
@@ -14,9 +14,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.18.1",
-    "@aptos-labs/wallet-adapter-ant-design": "^2.4.5",
-    "@aptos-labs/wallet-adapter-react": "^3.1.0",
+    "@aptos-labs/ts-sdk": "^1.19.0",
+    "@aptos-labs/wallet-adapter-react": "^3.3.0",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",


### PR DESCRIPTION
While working on the front-end docs for CAD, I was thinking about adding some instructions for how to add dark mode. To see how easy it would be, I tried adding the shadcn theme provider to one of the dapps I generated from the template and almost everything worked out of the box — there were just a few elements that needed a little more CSS to support dark mode. This PR fixes those elements so that dark mode is as easy as adding the theme provider and a theme toggle.

While I was in the codebase, I did a little misc. cleanup:
- Remove the antd wallet adapter from the template dependencies
- Update to the latest shadcn wallet selector
- Add Toaster to the templates so that wallet errors don't go to the void