### PR TITLE
fix mint fee unit

### DIFF
--- a/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
+++ b/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
@@ -1,20 +1,12 @@
 import { Button, buttonVariants } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useRef, useState } from "react";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { aptosClient } from "@/utils/aptosClient";
 import { uploadCollectionData } from "@/utils/assetsUploader";
-import {
-  APT_DECIMALS,
-  convertAmountFromHumanReadableToOnChain,
-} from "@/utils/helpers";
+import { APT_DECIMALS, convertAmountFromHumanReadableToOnChain } from "@/utils/helpers";
 import { Link, useNavigate } from "react-router-dom";
 
 import { dateToSeconds } from "../utils/helpers";
@@ -49,9 +41,7 @@ export function CreateCollection() {
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const onPublicMintStartTime = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const onPublicMintStartTime = (event: React.ChangeEvent<HTMLInputElement>) => {
     const timeValue = event.target.value;
     setPublicMintStartTime(timeValue);
 
@@ -84,14 +74,14 @@ export function CreateCollection() {
 
       setIsUploading(true);
 
-      const { collectionName, collectionDescription, maxSupply, projectUri } =
-        await uploadCollectionData(aptosWallet, files);
+      const { collectionName, collectionDescription, maxSupply, projectUri } = await uploadCollectionData(
+        aptosWallet,
+        files,
+      );
 
       const response = await signAndSubmitTransaction({
         data: {
-          function: `${
-            import.meta.env.VITE_MODULE_ADDRESS
-          }::launchpad::create_collection`,
+          function: `${import.meta.env.VITE_MODULE_ADDRESS}::launchpad::create_collection`,
           typeArguments: [],
           functionArguments: [
             collectionDescription,
@@ -108,20 +98,14 @@ export function CreateCollection() {
             dateToSeconds(publicMintStartDate), // public mint start time (in seconds)
             dateToSeconds(publicMintEndDate), // public mint end time (in seconds)
             mintLimitPerAccount, // mint limit per address in the public mint
-            mintFeePerNFT
-              ? convertAmountFromHumanReadableToOnChain(
-                  mintFeePerNFT,
-                  APT_DECIMALS
-                )
-              : 0, // mint fee per NFT for the public mint, on chain stored in smallest unit of APT (i.e. 1e8 oAPT = 1 APT)
+            mintFeePerNFT ? convertAmountFromHumanReadableToOnChain(mintFeePerNFT, APT_DECIMALS) : 0, // mint fee per NFT for the public mint, on chain stored in smallest unit of APT (i.e. 1e8 oAPT = 1 APT)
           ],
         },
       });
 
-      const committedTransactionResponse =
-        await aptosClient().waitForTransaction({
-          transactionHash: response.hash,
-        });
+      const committedTransactionResponse = await aptosClient().waitForTransaction({
+        transactionHash: response.hash,
+      });
       if (committedTransactionResponse.success) {
         navigate(`/my-collections`, { replace: true });
       }
@@ -139,13 +123,9 @@ export function CreateCollection() {
       <div className="flex flex-col md:flex-row items-start justify-between px-4 py-2 gap-4 max-w-screen-xl mx-auto">
         <div className="w-full md:w-2/3 flex flex-col gap-y-4 order-2 md:order-1">
           {(!account || account.address !== CREATOR_ADDRESS) && (
-            <WarningAlert
-              title={
-                account ? "Wrong account connected" : "No account connected"
-              }>
-              To continue with creating your collection, make sure you are
-              connected with a Wallet and with the same profile account as in
-              your CREATOR_ADDRESS in{" "}
+            <WarningAlert title={account ? "Wrong account connected" : "No account connected"}>
+              To continue with creating your collection, make sure you are connected with a Wallet and with the same
+              profile account as in your CREATOR_ADDRESS in{" "}
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
                 .env
               </code>{" "}
@@ -157,9 +137,7 @@ export function CreateCollection() {
 
           <Card>
             <CardHeader>
-              <CardDescription>
-                Uploads collection files to Irys, a decentralized storage
-              </CardDescription>
+              <CardDescription>Uploads collection files to Irys, a decentralized storage</CardDescription>
             </CardHeader>
             <CardContent>
               <div className="flex flex-col items-start justify-between">
@@ -197,7 +175,8 @@ export function CreateCollection() {
                       onClick={() => {
                         setFiles(null);
                         inputRef.current!.value = "";
-                      }}>
+                      }}
+                    >
                       Clear
                     </Button>
                   </div>
@@ -256,7 +235,7 @@ export function CreateCollection() {
           <LabeledInput
             id="mint-fee"
             label="Mint fee per NFT in APT"
-            tooltip="The fee the nft minter is paying the collection creator when they mint an NFT"
+            tooltip="The fee the nft minter is paying the collection creator when they mint an NFT, denominated in APT"
             disabled={isUploading || !account}
             onChange={(e) => {
               setMintFeePerNFT(parseInt(e.target.value));
@@ -278,31 +257,17 @@ export function CreateCollection() {
             className="self-start"
             onSubmit={createCollection}
             disabled={
-              !account ||
-              !files?.length ||
-              !publicMintStartDate ||
-              !mintLimitPerAccount ||
-              !account ||
-              isUploading
+              !account || !files?.length || !publicMintStartDate || !mintLimitPerAccount || !account || isUploading
             }
             confirmMessage={
               <>
                 <p>The upload process requires at least 2 message signatures</p>
                 <ol className="list-decimal list-inside">
-                  <li>
-                    To upload collection cover image file and NFT image files
-                    into Irys.
-                  </li>
+                  <li>To upload collection cover image file and NFT image files into Irys.</li>
 
-                  <li>
-                    To upload collection metadata file and NFT metadata files
-                    into Irys.
-                  </li>
+                  <li>To upload collection metadata file and NFT metadata files into Irys.</li>
                 </ol>
-                <p>
-                  In the case we need to fund a node on Irys, a transfer
-                  transaction submission is required also.
-                </p>
+                <p>In the case we need to fund a node on Irys, a transfer transaction submission is required also.</p>
               </>
             }
           />
@@ -311,10 +276,7 @@ export function CreateCollection() {
           <Card>
             <CardHeader className="body-md-semibold">Learn More</CardHeader>
             <CardContent>
-              <Link
-                to="https://aptos.dev/standards/digital-asset"
-                className="body-sm underline"
-                target="_blank">
+              <Link to="https://aptos.dev/standards/digital-asset" className="body-sm underline" target="_blank">
                 Find out more about Digital Assets on Aptos
               </Link>
             </CardContent>

--- a/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
+++ b/templates/digital-asset-template/frontend/pages/CreateCollection.tsx
@@ -125,7 +125,7 @@ export function CreateCollection() {
           {(!account || account.address !== CREATOR_ADDRESS) && (
             <WarningAlert title={account ? "Wrong account connected" : "No account connected"}>
               To continue with creating your collection, make sure you are connected with a Wallet and with the same
-              profile account as in your CREATOR_ADDRESS in{" "}
+              profile account as in your COLLECTION_CREATOR_ADDRESS in{" "}
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
                 .env
               </code>{" "}
@@ -238,7 +238,7 @@ export function CreateCollection() {
             tooltip="The fee the nft minter is paying the collection creator when they mint an NFT, denominated in APT"
             disabled={isUploading || !account}
             onChange={(e) => {
-              setMintFeePerNFT(parseInt(e.target.value));
+              setMintFeePerNFT(Number(e.target.value));
             }}
           />
 

--- a/templates/digital-asset-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/digital-asset-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -37,7 +37,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
 
     const transaction: InputTransactionData = {
       data: {
-        function: `${MODULE_ADDRESS}::launchpad::batch_mint_nft`,
+        function: `${MODULE_ADDRESS}::launchpad::mint_nft`,
         functionArguments: [collection?.collection_id, nftCount],
       },
     };

--- a/templates/fungible-asset-template/frontend/constants.ts
+++ b/templates/fungible-asset-template/frontend/constants.ts
@@ -1,4 +1,4 @@
 export const NETWORK = import.meta.env.VITE_APP_NETWORK ?? "testnet";
 export const MODULE_ADDRESS = import.meta.env.VITE_MODULE_ADDRESS;
-export const CREATOR_ADDRESS = import.meta.env.VITE_COLLECTION_CREATOR_ADDRESS;
+export const CREATOR_ADDRESS = import.meta.env.VITE_FA_CREATOR_ADDRESS;
 export const IS_DEV = Boolean(import.meta.env.DEV);

--- a/templates/fungible-asset-template/frontend/pages/CreateFungibleAsset.tsx
+++ b/templates/fungible-asset-template/frontend/pages/CreateFungibleAsset.tsx
@@ -64,11 +64,11 @@ export function CreateFungibleAsset() {
             projectURL,
             mintFeePerFA
               ? convertAmountFromOnChainToHumanReadable(
-                  convertAmountFromHumanReadableToOnChain(parseInt(mintFeePerFA), APT_DECIMALS),
+                  convertAmountFromHumanReadableToOnChain(Number(mintFeePerFA), APT_DECIMALS),
                   Number(decimal),
                 )
               : 0,
-            mintForMyself ? convertAmountFromHumanReadableToOnChain(parseInt(mintForMyself), Number(decimal)) : 0,
+            mintForMyself ? convertAmountFromHumanReadableToOnChain(Number(mintForMyself), Number(decimal)) : 0,
             maxMintPerAccount ? convertAmountFromHumanReadableToOnChain(maxMintPerAccount, Number(decimal)) : 0,
           ],
         },
@@ -95,7 +95,7 @@ export function CreateFungibleAsset() {
           {(!account || account.address !== CREATOR_ADDRESS) && (
             <WarningAlert title={account ? "Wrong account connected" : "No account connected"}>
               To continue with creating your collection, make sure you are connected with a Wallet and with the same
-              profile account as in your CREATOR_ADDRESS in{" "}
+              profile account as in your FA_CREATOR_ADDRESS in{" "}
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
                 .env
               </code>{" "}
@@ -179,7 +179,7 @@ export function CreateFungibleAsset() {
           <LabeledInput
             id="max-supply"
             label="Max Supply"
-            tooltip="The total amount of the asset that can be minted."
+            tooltip="The total amount of the asset in full unit that can be minted."
             required
             onChange={(e) => setMaxSupply(e.target.value)}
             disabled={isUploading || !account}
@@ -188,10 +188,10 @@ export function CreateFungibleAsset() {
 
           <LabeledInput
             id="max-mint"
-            label="Max mint in full unit of an asset per account"
-            tooltip="The maximum any single individual address can mint"
+            label="Max amount an address can mint"
+            tooltip="The maximum amount in full unit that any single individual address can mint"
             required
-            onChange={(e) => setMaxMintPerAccount(parseInt(e.target.value))}
+            onChange={(e) => setMaxMintPerAccount(Number(e.target.value))}
             disabled={isUploading || !account}
             type="number"
           />
@@ -218,8 +218,8 @@ export function CreateFungibleAsset() {
 
           <LabeledInput
             id="mint-fee"
-            label="Mint fee per one full unit of fungible asset in APT"
-            tooltip="The fee cost for the minter to pay to mint one full unit of an asset. For example, if a user mints 10 assets in a single transaction, they are charged 10x the mint fee."
+            label="Mint fee per fungible asset in APT"
+            tooltip="The fee cost for the minter to pay to mint one full unit of an asset, denominated in APT. For example, if a user mints 10 assets in a single transaction, they are charged 10x the mint fee."
             onChange={(e) => setMintFeePerFA(e.target.value)}
             disabled={isUploading || !account}
             type="number"
@@ -228,7 +228,7 @@ export function CreateFungibleAsset() {
           <LabeledInput
             id="for-myself"
             label="Mint for myself"
-            tooltip="How many assets to mint right away and send to your address."
+            tooltip="How many assets in full unit to mint right away and send to your address."
             onChange={(e) => setMintForMyself(e.target.value)}
             disabled={isUploading || !account}
             type="number"

--- a/templates/fungible-asset-template/frontend/pages/CreateFungibleAsset.tsx
+++ b/templates/fungible-asset-template/frontend/pages/CreateFungibleAsset.tsx
@@ -1,11 +1,5 @@
 import { Button, buttonVariants } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -17,6 +11,7 @@ import { aptosClient } from "@/utils/aptosClient";
 import {
   APT_DECIMALS,
   convertAmountFromHumanReadableToOnChain,
+  convertAmountFromOnChainToHumanReadable,
 } from "@/utils/helpers";
 import { LaunchpadHeader } from "@/components/LaunchpadHeader";
 import { CREATOR_ADDRESS } from "@/constants";
@@ -42,14 +37,7 @@ export function CreateFungibleAsset() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const disableCreateAssetButton =
-    !name ||
-    !symbol ||
-    !maxSupply ||
-    !decimal ||
-    !projectURL ||
-    !maxMintPerAccount ||
-    !account ||
-    isUploading;
+    !name || !symbol || !maxSupply || !decimal || !projectURL || !maxMintPerAccount || !account || isUploading;
 
   const createAsset = async () => {
     try {
@@ -59,50 +47,36 @@ export function CreateFungibleAsset() {
       setIsUploading(true);
 
       const funded = await checkIfFund(aptosWallet, image.size);
-      if (!funded)
-        throw new Error(
-          "Current account balance is not enough to fund a decentralized asset node"
-        );
+      if (!funded) throw new Error("Current account balance is not enough to fund a decentralized asset node");
 
       const iconURL = await uploadFile(aptosWallet, image);
 
       const response = await signAndSubmitTransaction({
         data: {
-          function: `${
-            import.meta.env.VITE_MODULE_ADDRESS
-          }::launchpad::create_fa`,
+          function: `${import.meta.env.VITE_MODULE_ADDRESS}::launchpad::create_fa`,
           typeArguments: [],
           functionArguments: [
-            convertAmountFromHumanReadableToOnChain(
-              Number(maxSupply),
-              Number(decimal)
-            ),
+            convertAmountFromHumanReadableToOnChain(Number(maxSupply), Number(decimal)),
             name,
             symbol,
             decimal,
             iconURL,
             projectURL,
             mintFeePerFA
-              ? convertAmountFromHumanReadableToOnChain(
-                  parseInt(mintFeePerFA),
-                  APT_DECIMALS
+              ? convertAmountFromOnChainToHumanReadable(
+                  convertAmountFromHumanReadableToOnChain(parseInt(mintFeePerFA), APT_DECIMALS),
+                  Number(decimal),
                 )
               : 0,
-            mintForMyself,
-            maxMintPerAccount
-              ? convertAmountFromHumanReadableToOnChain(
-                  maxMintPerAccount,
-                  parseInt(decimal!)
-                )
-              : 0,
+            mintForMyself ? convertAmountFromHumanReadableToOnChain(parseInt(mintForMyself), Number(decimal)) : 0,
+            maxMintPerAccount ? convertAmountFromHumanReadableToOnChain(maxMintPerAccount, Number(decimal)) : 0,
           ],
         },
       });
 
-      const committedTransactionResponse =
-        await aptosClient().waitForTransaction({
-          transactionHash: response.hash,
-        });
+      const committedTransactionResponse = await aptosClient().waitForTransaction({
+        transactionHash: response.hash,
+      });
       if (committedTransactionResponse.success) {
         navigate(`/my-assets`, { replace: true });
       }
@@ -119,13 +93,9 @@ export function CreateFungibleAsset() {
       <div className="flex flex-col md:flex-row items-start justify-between px-4 py-2 gap-4 max-w-screen-xl mx-auto">
         <div className="w-full md:w-2/3 flex flex-col gap-y-4 order-2 md:order-1">
           {(!account || account.address !== CREATOR_ADDRESS) && (
-            <WarningAlert
-              title={
-                account ? "Wrong account connected" : "No account connected"
-              }>
-              To continue with creating your collection, make sure you are
-              connected with a Wallet and with the same profile account as in
-              your CREATOR_ADDRESS in{" "}
+            <WarningAlert title={account ? "Wrong account connected" : "No account connected"}>
+              To continue with creating your collection, make sure you are connected with a Wallet and with the same
+              profile account as in your CREATOR_ADDRESS in{" "}
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
                 .env
               </code>{" "}
@@ -138,9 +108,7 @@ export function CreateFungibleAsset() {
           <Card>
             <CardHeader>
               <CardTitle>Asset Image</CardTitle>
-              <CardDescription>
-                Uploads asset to a decentralized storage
-              </CardDescription>
+              <CardDescription>Uploads asset to a decentralized storage</CardDescription>
             </CardHeader>
             <CardContent>
               <div className="flex flex-col items-start justify-between">
@@ -150,7 +118,8 @@ export function CreateFungibleAsset() {
                     className={buttonVariants({
                       variant: "outline",
                       className: "cursor-pointer",
-                    })}>
+                    })}
+                  >
                     Choose Image
                   </Label>
                 )}
@@ -176,7 +145,8 @@ export function CreateFungibleAsset() {
                         onClick={() => {
                           setImage(null);
                           inputRef.current!.value = "";
-                        }}>
+                        }}
+                      >
                         Clear
                       </Button>
                     </p>
@@ -218,7 +188,7 @@ export function CreateFungibleAsset() {
 
           <LabeledInput
             id="max-mint"
-            label="Max mint per account"
+            label="Max mint in full unit of an asset per account"
             tooltip="The maximum any single individual address can mint"
             required
             onChange={(e) => setMaxMintPerAccount(parseInt(e.target.value))}
@@ -248,8 +218,8 @@ export function CreateFungibleAsset() {
 
           <LabeledInput
             id="mint-fee"
-            label="Mint fee per fungible asset in APT"
-            tooltip="The fee cost for the minter to pay to mint one asset. For example, if a user mints 10 assets in a single transaction, they are charged 10x the mint fee."
+            label="Mint fee per one full unit of fungible asset in APT"
+            tooltip="The fee cost for the minter to pay to mint one full unit of an asset. For example, if a user mints 10 assets in a single transaction, they are charged 10x the mint fee."
             onChange={(e) => setMintFeePerFA(e.target.value)}
             disabled={isUploading || !account}
             type="number"
@@ -272,13 +242,9 @@ export function CreateFungibleAsset() {
             confirmMessage={
               <>
                 <p>
-                  The upload process requires at least 1 message signatures to
-                  upload the asset image file into Irys.
+                  The upload process requires at least 1 message signatures to upload the asset image file into Irys.
                 </p>
-                <p>
-                  In the case we need to fund a node on Irys, a transfer
-                  transaction submission is required also.
-                </p>
+                <p>In the case we need to fund a node on Irys, a transfer transaction submission is required also.</p>
               </>
             }
           />
@@ -291,7 +257,8 @@ export function CreateFungibleAsset() {
               <Link
                 to="https://aptos.dev/standards/fungible-asset"
                 style={{ textDecoration: "underline" }}
-                target="_blank">
+                target="_blank"
+              >
                 Find out more about Fungible Assets on Aptos
               </Link>
             </CardContent>
@@ -301,4 +268,3 @@ export function CreateFungibleAsset() {
     </>
   );
 }
-

--- a/templates/fungible-asset-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/fungible-asset-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -27,7 +27,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
 
   const { asset, totalAbleToMint = 0, yourBalance = 0 } = data ?? {};
 
-  const mintNft = async (e: FormEvent) => {
+  const mintFA = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
 
@@ -51,10 +51,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
     const response = await signAndSubmitTransaction({
       data: {
         function: `${MODULE_ADDRESS}::launchpad::mint_fa`,
-        functionArguments: [
-          asset.asset_type,
-          convertAmountFromHumanReadableToOnChain(amount, asset.decimals),
-        ],
+        functionArguments: [asset.asset_type, convertAmountFromHumanReadableToOnChain(amount, asset.decimals)],
       },
     });
     await aptosClient().waitForTransaction({ transactionHash: response.hash });
@@ -76,10 +73,9 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
         <Card>
           <CardContent
             fullPadding
-            className="flex flex-col md:flex-row gap-4 md:justify-between items-start md:items-center">
-            <form
-              onSubmit={mintNft}
-              className="flex flex-col md:flex-row gap-4 w-full md:basis-1/4">
+            className="flex flex-col md:flex-row gap-4 md:justify-between items-start md:items-center"
+          >
+            <form onSubmit={mintFA} className="flex flex-col md:flex-row gap-4 w-full md:basis-1/4">
               <Input
                 type="text"
                 name="amount"
@@ -119,7 +115,8 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
             <a
               className={buttonVariants({ variant: "link" })}
               target="_blank"
-              href={`https://explorer.aptoslabs.com/account/${asset?.asset_type}?network=${NETWORK}`}>
+              href={`https://explorer.aptoslabs.com/account/${asset?.asset_type}?network=${NETWORK}`}
+            >
               View on Explorer <Image src={ExternalLink} />
             </a>
           </div>
@@ -140,11 +137,7 @@ const AddressButton: FC<{ address: string }> = ({ address }) => {
   }
 
   return (
-    <Button
-      onClick={onCopy}
-      className="whitespace-nowrap flex gap-1 px-0 py-0"
-      variant="link"
-    >
+    <Button onClick={onCopy} className="whitespace-nowrap flex gap-1 px-0 py-0" variant="link">
       {copied ? (
         "Copied!"
       ) : (

--- a/templates/fungible-asset-template/scripts/move/compile.js
+++ b/templates/fungible-asset-template/scripts/move/compile.js
@@ -8,9 +8,9 @@ const accountAddress =
   config["profiles"][process.env.VITE_APP_NETWORK]["account"];
 
 async function compile() {
-  if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {
+  if (!process.env.VITE_FA_CREATOR_ADDRESS) {
     throw new Error(
-      "VITE_COLLECTION_CREATOR_ADDRESS variable is not set, make sure you set it on the .env file"
+      "VITE_FA_CREATOR_ADDRESS variable is not set, make sure you set it on the .env file"
     );
   }
   const move = new cli.Move();
@@ -21,7 +21,7 @@ async function compile() {
       // Publish module to account address
       launchpad_addr: accountAddress,
       // This is the address you want to use to create collection with, e.g. an address in Petra so you can create collection in UI using Petra
-      initial_creator_addr: process.env.VITE_COLLECTION_CREATOR_ADDRESS,
+      initial_creator_addr: process.env.VITE_FA_CREATOR_ADDRESS,
     },
   });
 }

--- a/templates/fungible-asset-template/scripts/move/publish.js
+++ b/templates/fungible-asset-template/scripts/move/publish.js
@@ -8,9 +8,9 @@ const accountAddress =
   config["profiles"][process.env.VITE_APP_NETWORK]["account"];
 
 async function publish() {
-  if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {
+  if (!process.env.VITE_FA_CREATOR_ADDRESS) {
     throw new Error(
-      "VITE_COLLECTION_CREATOR_ADDRESS variable is not set, make sure you set it on the .env file"
+      "VITE_FA_CREATOR_ADDRESS variable is not set, make sure you set it on the .env file"
     );
   }
   const move = new cli.Move();
@@ -21,7 +21,7 @@ async function publish() {
       // Publish module to account address
       launchpad_addr: accountAddress,
       // This is the address you want to use to create collection with, e.g. an address in Petra so you can create collection in UI using Petra
-      initial_creator_addr: process.env.VITE_COLLECTION_CREATOR_ADDRESS,
+      initial_creator_addr: process.env.VITE_FA_CREATOR_ADDRESS,
     },
     profile: process.env.VITE_APP_NETWORK,
   });


### PR DESCRIPTION
When it comes to amount, all number on chain should be in smallest unit. Previously `mint_fee_per_fa` is in smallest unit of APT for smallest unit of FA, rename it to `mint_fee_per_smallest_unit_of_fa` to avoid confusion and handle conversion on the UI.

Tested e2e by creating a FA with mint fee per FA set to 0.12 on the UI, FA has 3 decimals. I tried to mint 1 on UI which costs me 0.12 APT, which looks right.