### PR TITLE
Namespaces aptos cli profile with the project name

### DIFF
--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -101,13 +101,17 @@ export async function generateDapp(selection: Selections) {
 
     // create .env file
     const network = selection.network || "testnet";
+    const assetType =
+      selection.template.path === "digital-asset-template"
+        ? "COLLECTION"
+        : "FA";
     await write(
       ".env",
-      `VITE_APP_NETWORK=${network}\nVITE_${
-        selection.template.path === "digital-asset-template"
-          ? "COLLECTION"
-          : "FA"
-      }_CREATOR_ADDRESS=""`
+      Object.entries({
+        PROFILE_NAME: `${projectName}-${network}`,
+        VITE_APP_NETWORK: network,
+        [`VITE_${assetType}_CREATOR_ADDRESS`]: "",
+      }).reduce((acc, [key, value]) => acc + `${key}=${value}` + "\n", "")
     );
 
     // Log next steps

--- a/templates/digital-asset-template/scripts/init.js
+++ b/templates/digital-asset-template/scripts/init.js
@@ -7,7 +7,7 @@ async function init() {
 
   await move.init({
     network: process.env.VITE_APP_NETWORK,
-    profile: process.env.VITE_APP_NETWORK,
+    profile: process.env.PROFILE_NAME,
   });
 }
 init();

--- a/templates/digital-asset-template/scripts/move/compile.js
+++ b/templates/digital-asset-template/scripts/move/compile.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 async function compile() {
   if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {

--- a/templates/digital-asset-template/scripts/move/publish.js
+++ b/templates/digital-asset-template/scripts/move/publish.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 async function publish() {
   if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {
@@ -29,7 +29,7 @@ async function publish() {
       minter:
         "0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490",
     },
-    profile: process.env.VITE_APP_NETWORK,
+    profile: process.env.PROFILE_NAME,
   });
 }
 publish();

--- a/templates/digital-asset-template/scripts/update_env.js
+++ b/templates/digital-asset-template/scripts/update_env.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 const filePath = ".env";
 let envContent = "";

--- a/templates/fungible-asset-template/scripts/init.js
+++ b/templates/fungible-asset-template/scripts/init.js
@@ -7,7 +7,7 @@ async function init() {
 
   await move.init({
     network: process.env.VITE_APP_NETWORK,
-    profile: process.env.VITE_APP_NETWORK,
+    profile: process.env.PROFILE_NAME,
   });
 }
 init();

--- a/templates/fungible-asset-template/scripts/move/compile.js
+++ b/templates/fungible-asset-template/scripts/move/compile.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 async function compile() {
   if (!process.env.VITE_FA_CREATOR_ADDRESS) {

--- a/templates/fungible-asset-template/scripts/move/publish.js
+++ b/templates/fungible-asset-template/scripts/move/publish.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 async function publish() {
   if (!process.env.VITE_FA_CREATOR_ADDRESS) {
@@ -23,7 +23,7 @@ async function publish() {
       // This is the address you want to use to create collection with, e.g. an address in Petra so you can create collection in UI using Petra
       initial_creator_addr: process.env.VITE_FA_CREATOR_ADDRESS,
     },
-    profile: process.env.VITE_APP_NETWORK,
+    profile: process.env.PROFILE_NAME,
   });
 }
 publish();

--- a/templates/fungible-asset-template/scripts/update_env.js
+++ b/templates/fungible-asset-template/scripts/update_env.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.VITE_APP_NETWORK]["account"];
+  config["profiles"][process.env.PROFILE_NAME]["account"];
 
 const filePath = ".env";
 let envContent = "";


### PR DESCRIPTION
[use cli profile as <project-name>-<network> to not conflict with a possible global config file](https://www.notion.so/aptoslabs/use-cli-profile-as-project-name-network-to-not-conflict-with-a-possible-global-config-file-b857afac76d34bfa97c9884b605cc32e).

Tested with `npm run move:init` and `npm run move:publish`. Full flow worked. 