### PR TITLE
Fixes namespace issue

### DIFF
--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -108,7 +108,7 @@ export async function generateDapp(selection: Selections) {
     await write(
       ".env",
       Object.entries({
-        PROFILE_NAME: `${projectName}-${network}`,
+        PROJECT_NAME: projectName,
         VITE_APP_NETWORK: network,
         [`VITE_${assetType}_CREATOR_ADDRESS`]: "",
       }).reduce((acc, [key, value]) => acc + `${key}=${value}` + "\n", "")

--- a/templates/digital-asset-template/scripts/init.js
+++ b/templates/digital-asset-template/scripts/init.js
@@ -7,7 +7,7 @@ async function init() {
 
   await move.init({
     network: process.env.VITE_APP_NETWORK,
-    profile: process.env.PROFILE_NAME,
+    profile: `${process.env.PROJECT_NAME}-${process.env.VITE_APP_NETWORK}`,
   });
 }
 init();

--- a/templates/digital-asset-template/scripts/move/compile.js
+++ b/templates/digital-asset-template/scripts/move/compile.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 async function compile() {
   if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {

--- a/templates/digital-asset-template/scripts/move/publish.js
+++ b/templates/digital-asset-template/scripts/move/publish.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 async function publish() {
   if (!process.env.VITE_COLLECTION_CREATOR_ADDRESS) {
@@ -29,7 +29,7 @@ async function publish() {
       minter:
         "0x3c41ff6b5845e0094e19888cba63773591be9de59cafa9e582386f6af15dd490",
     },
-    profile: process.env.PROFILE_NAME,
+    profile: `${process.env.PROJECT_NAME}-${process.env.VITE_APP_NETWORK}`,
   });
 }
 publish();

--- a/templates/digital-asset-template/scripts/update_env.js
+++ b/templates/digital-asset-template/scripts/update_env.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 const filePath = ".env";
 let envContent = "";

--- a/templates/fungible-asset-template/scripts/init.js
+++ b/templates/fungible-asset-template/scripts/init.js
@@ -7,7 +7,7 @@ async function init() {
 
   await move.init({
     network: process.env.VITE_APP_NETWORK,
-    profile: process.env.PROFILE_NAME,
+    profile: `${process.env.PROJECT_NAME}-${process.env.VITE_APP_NETWORK}`,
   });
 }
 init();

--- a/templates/fungible-asset-template/scripts/move/compile.js
+++ b/templates/fungible-asset-template/scripts/move/compile.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 async function compile() {
   if (!process.env.VITE_FA_CREATOR_ADDRESS) {

--- a/templates/fungible-asset-template/scripts/move/publish.js
+++ b/templates/fungible-asset-template/scripts/move/publish.js
@@ -5,7 +5,7 @@ const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 async function publish() {
   if (!process.env.VITE_FA_CREATOR_ADDRESS) {
@@ -23,7 +23,7 @@ async function publish() {
       // This is the address you want to use to create collection with, e.g. an address in Petra so you can create collection in UI using Petra
       initial_creator_addr: process.env.VITE_FA_CREATOR_ADDRESS,
     },
-    profile: process.env.PROFILE_NAME,
+    profile: `${process.env.PROJECT_NAME}-${process.env.VITE_APP_NETWORK}`,
   });
 }
 publish();

--- a/templates/fungible-asset-template/scripts/update_env.js
+++ b/templates/fungible-asset-template/scripts/update_env.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 const config = yaml.load(fs.readFileSync("./.aptos/config.yaml", "utf8"));
 const accountAddress =
-  config["profiles"][process.env.PROFILE_NAME]["account"];
+  config["profiles"][process.env.PROJECT_NAME]["account"];
 
 const filePath = ".env";
 let envContent = "";


### PR DESCRIPTION
I was updating the dev docs and ran into an issue when users try and migrate to mainnet. We tell them to manually change the network value in the `.env` file. That complicated the profile namespace a bit. I opted to save the project name, and then derive the profile name in the scripts vs saving the derived value.  

Updating the dev docs now.