### PR TITLE
Fix AptosConnect not showing up on the public mint page

### DIFF
--- a/templates/digital-asset-template/frontend/components/WalletSelector.tsx
+++ b/templates/digital-asset-template/frontend/components/WalletSelector.tsx
@@ -88,7 +88,7 @@ function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
 
   const location = useLocation();
 
-  const isPublicMintPage = location.pathname === "/";
+  const isPublicMintPage = location.pathname !== "/create-collection" && location.pathname !== "/my-collections";
 
   const {
     /** Wallets that use social login to create an account on the blockchain */

--- a/templates/fungible-asset-template/frontend/components/WalletSelector.tsx
+++ b/templates/fungible-asset-template/frontend/components/WalletSelector.tsx
@@ -88,7 +88,7 @@ function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
 
   const location = useLocation();
 
-  const isPublicMintPage = location.pathname === "/";
+  const isPublicMintPage = location.pathname !== "/create-collection" && location.pathname !== "/my-collections";
 
   const {
     /** Wallets that use social login to create an account on the blockchain */


### PR DESCRIPTION
The public mint page is not guaranteed to be deployed under the `/` route (for example when the dapp is being deployed under www.example.com/homepage), so changing to explicitly not show AptosConnect on Create Collection and My Collections pages. 