### PR TITLE
Add a telemetry tool integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 # Unreleased
 
+- Add a telemetry tool integration
+
 # 0.0.13 (2024-07-15)
 
 - Add `dotenv` dev dependency to the `Boilerplate` template

--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -5,8 +5,10 @@ import fs from "fs/promises";
 import type { Ora } from "ora";
 import ora from "ora";
 import { exec } from "child_process";
+// internal files
 import { Selections } from "./types.js";
 import { copy } from "./utils/helpers.js";
+import { recordTelemetry } from "./telemetry.js";
 
 const spinner = (text) => ora({ text, stream: process.stdout });
 let currentSpinner: Ora | null = null;
@@ -121,6 +123,11 @@ export async function generateDapp(selection: Selections) {
     // install dependencies
     const installRootDepsCommand = `npm install --silent --no-progress`;
     await runCommand(installRootDepsCommand);
+
+    // If approve telemetry
+    if (selection.telemetry) {
+      await recordTelemetry(selection);
+    }
 
     npmSpinner.succeed();
     currentSpinner = npmSpinner;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from "node:crypto";
+import { GA4_URL } from "./utils/constants.js";
+import { getOS } from "./utils/helpers.js";
+import { Selections } from "./types.js";
+
+export const recordTelemetry = async (selection: Selections) => {
+  try {
+    const telemetry = {
+      client_id: randomUUID(), // We generate a random client id for each request
+      user_id: randomUUID(), // can we find a better way of identifying each CLI user?
+      timestamp_micros: (Date.now() * 1000).toString(),
+      events: [
+        {
+          name: "wizard_command",
+          params: {
+            command: "npx create-aptos-dapp", // TODO make it generic once --example is introduced
+            project_name: selection.projectName,
+            template: selection.template.name,
+            network: selection.network,
+            os: getOS(),
+          },
+        },
+      ],
+    };
+    const res = await fetch(GA4_URL, {
+      method: "POST",
+      body: JSON.stringify(telemetry),
+      headers: { "content-type": "application/json" },
+    });
+    // this is helpful when using GA4_URL_DEBUG to debug GA4 query. GA4_URL does not return any body response back
+    if (res.body) {
+      const resJson = await res.json();
+      console.log("ga4 debug response", resJson);
+    }
+  } catch (err: any) {
+    console.log("could not record telemetry data", err);
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,4 +16,5 @@ export type Selections = {
   projectName: string;
   template: Template;
   network: Network;
+  telemetry: boolean;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,5 @@
+// GA4
+export const GA_MEASURMENT_ID = "G-QCE2R28N2J";
+export const GA_CLIENT_ID = "Xhptd45qQKiPALmqqRheqg";
+export const GA4_URL = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASURMENT_ID}&api_secret=${GA_CLIENT_ID}`;
+export const GA4_URL_DEBUG = `https://www.google-analytics.com/debug/mp/collect?measurement_id=${GA_MEASURMENT_ID}&api_secret=${GA_CLIENT_ID}`;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 import path from "path";
 import fs from "node:fs";
+import os from "node:os";
 
 export const runCommand = (command) => {
   try {
@@ -12,6 +13,7 @@ export const runCommand = (command) => {
   return true;
 };
 
+// Copy a full source directory into a destination directory
 export const copy = (src: string, dest: string) => {
   const stat = fs.statSync(src);
   if (stat.isDirectory()) {
@@ -21,12 +23,28 @@ export const copy = (src: string, dest: string) => {
   }
 };
 
+// Copr a source directory into a destination directory
 export const copyDir = (srcDir: string, destDir: string) => {
   fs.mkdirSync(destDir, { recursive: true });
   for (const file of fs.readdirSync(srcDir)) {
     const srcFile = path.resolve(srcDir, file);
     const destFile = path.resolve(destDir, file);
     copy(srcFile, destFile);
+  }
+};
+
+// Get the user OS
+export const getOS = () => {
+  const platform = os.platform();
+  switch (platform) {
+    case "darwin":
+      return "MacOS";
+    case "linux":
+      return "Ubuntu";
+    case "win32":
+      return "Windows";
+    default:
+      return `Unsupported OS ${platform}`;
   }
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -23,7 +23,7 @@ export const copy = (src: string, dest: string) => {
   }
 };
 
-// Copr a source directory into a destination directory
+// Copy a source directory into a destination directory
 export const copyDir = (srcDir: string, destDir: string) => {
   fs.mkdirSync(destDir, { recursive: true });
   for (const file of fs.readdirSync(srcDir)) {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -16,6 +16,7 @@ export async function startWorkflow() {
         },
         workflowOptions.template,
         workflowOptions.network,
+        workflowOptions.analytics,
       ],
       {
         onCancel: () => {
@@ -66,10 +67,11 @@ export async function startWorkflow() {
     process.exit(0);
   }
 
-  const { projectName, template, network } = result;
+  const { projectName, template, network, telemetry } = result;
   return {
     projectName,
     template,
     network,
+    telemetry,
   } as Selections;
 }

--- a/src/workflowOptions.ts
+++ b/src/workflowOptions.ts
@@ -47,7 +47,7 @@ export const workflowOptions = {
     type: "select",
     name: "network",
     message: "Choose your network",
-    choices(prev, values, prompt) {
+    choices(prev) {
       if (prev.path === "boilerplate-template") {
         return [
           { title: "Mainnet", value: "mainnet" },
@@ -62,5 +62,11 @@ export const workflowOptions = {
     },
     initial: 0,
     hint: "- You can change this later",
+  },
+  analytics: {
+    type: "confirm",
+    name: "telemetry",
+    message: "Help us improve create-aptos-dapp by collection anonymous data",
+    initial: true,
   },
 };


### PR DESCRIPTION
implement a telemetry tool in create-aptos-dapp where we send anonymous data to Google Analytics to understand user usage better and improve the tool. 

When a user goes into the create-aptos-dapp wizard flow, they are asked some questions, and we want to record their decisions.

The implementation is as follows: when the user enters the wizard flow, one of the steps is getting their confirmation on sending anonymous data. The syntax we use is:  Help us improve create-aptos-dapp by sending anonymous data.