### PR TITLE
Change asset_id -> fa_address

### DIFF
--- a/templates/token-minting-dapp-template/frontend/config.ts
+++ b/templates/token-minting-dapp-template/frontend/config.ts
@@ -2,7 +2,7 @@ import Placeholder1 from "@/assets/placeholders/asset.png";
 
 export const config: Config = {
   // TODO: Fill in your asset id
-  asset_id: "",
+  fa_address: "",
 
   // Removing one or all of these socials will remove them from the page
   socials: {
@@ -24,7 +24,7 @@ export const config: Config = {
 };
 
 export interface Config {
-  asset_id: string;
+  fa_address: string;
 
   socials?: {
     twitter?: string;

--- a/templates/token-minting-dapp-template/frontend/pages/Mint/components/ConnectWalletAlert.tsx
+++ b/templates/token-minting-dapp-template/frontend/pages/Mint/components/ConnectWalletAlert.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { config } from "@/config";
 
 export const ConnectWalletAlert: FC = () => {
-  if (config.asset_id) return null;
+  if (config.fa_address) return null;
 
   return (
     <div className="px-4">
@@ -23,7 +23,7 @@ export const ConnectWalletAlert: FC = () => {
             <li>
               Fill in the{" "}
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
-                asset_id
+                fa_address
               </code>{" "}
               field in
               <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">


### PR DESCRIPTION
Change copy to say `fa_address` instead of `asset_id`.

Before:
<img width="1192" alt="Screenshot 2024-07-30 at 4 43 29 PM" src="https://github.com/user-attachments/assets/c45e91b1-7a59-4409-a02d-69436d349cca">


After:
![Screenshot 2024-07-30 at 4 38 36 PM](https://github.com/user-attachments/assets/e3fe6730-5d3c-4657-9012-200349c34c5f)

Testing:
```
$pnpm install 
$pnpm dev 
$cd my-aptos-dapp
$npm run move:init
$npm run move:publish
```

Todo: update documentation to support `fa_address` wording
