### PR TITLE
Add a `deploy` npm command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 # Unreleased
 
+- Add a Staking template
+- Add a npm deploy command `npm run deploy`
+
 # 0.0.17 (2024-08-02)
 
 - Support an `--example` command to generate a specific example

--- a/templates/boilerplate-template/README.md
+++ b/templates/boilerplate-template/README.md
@@ -28,5 +28,6 @@ Some commands are built-in the template and can be ran as a npm script, for exam
 - `npm run move:publish` - a command to publish the Move contract
 - `npm run move:test` - a command to run Move unit tests
 - `npm run move:compile` - a command to compile the Move contract
+- `npm run deploy` - a command to deploy the dapp to Vercel
 
 For all other available CLI commands, can run `npx aptos` and see a list of all available commands.

--- a/templates/boilerplate-template/package.json
+++ b/templates/boilerplate-template/package.json
@@ -11,6 +11,7 @@
     "move:upgrade": "node ./scripts/move/upgrade",
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy":"vercel",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "_fmt": "prettier 'frontend/**/*.ts'",
@@ -52,6 +53,7 @@
     "vite": "^5.2.0",
     "vite-plugin-notifier": "^0.1.5",
     "tree-kill": "1.2.2",
-    "dotenv": "16.3.1"
+    "dotenv": "16.3.1",
+    "vercel": "^35.2.4"
   }
 }

--- a/templates/boilerplate-template/vite.config.ts
+++ b/templates/boilerplate-template/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   build: {
-    outDir: "build",
+    outDir: "dist",
   },
   server: {
     open: true,

--- a/templates/nft-minting-dapp-template/README.md
+++ b/templates/nft-minting-dapp-template/README.md
@@ -30,5 +30,6 @@ Some commands are built-in the template and can be ran as a npm script, for exam
 - `npm run move:upgrade` - a command to upgrade the Move contract
 - `npm run move:test` - a command to run Move unit tests
 - `npm run move:compile` - a command to compile the Move contract
+- `npm run deploy` - a command to deploy the dapp to Vercel
 
 For all other available CLI commands, can run `npx aptos` and see a list of all available commands.

--- a/templates/nft-minting-dapp-template/package.json
+++ b/templates/nft-minting-dapp-template/package.json
@@ -11,6 +11,7 @@
     "move:upgrade": "node ./scripts/move/upgrade",
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy":"vercel",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "_fmt": "prettier 'frontend/**/*.ts'",
@@ -69,6 +70,7 @@
     "vite": "^5.2.0",
     "vite-plugin-node-polyfills": "^0.21.0",
     "vite-plugin-notifier": "^0.1.5",
-    "prettier": "^3.3.2"
+    "prettier": "^3.3.2",
+    "vercel": "^35.2.4"
   }
 }

--- a/templates/nft-minting-dapp-template/vite.config.ts
+++ b/templates/nft-minting-dapp-template/vite.config.ts
@@ -5,7 +5,7 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 export default defineConfig({
   build: {
-    outDir: "build",
+    outDir: "dist",
   },
   server: {
     open: true,

--- a/templates/token-minting-dapp-template/README.md
+++ b/templates/token-minting-dapp-template/README.md
@@ -30,5 +30,6 @@ Some commands are built-in the template and can be ran as a npm script, for exam
 - `npm run move:upgrade` - a command to upgrade the Move contract
 - `npm run move:test` - a command to run Move unit tests
 - `npm run move:compile` - a command to compile the Move contract
+- `npm run deploy` - a command to deploy the dapp to Vercel
 
 For all other available CLI commands, can run `npx aptos` and see a list of all available commands.

--- a/templates/token-minting-dapp-template/package.json
+++ b/templates/token-minting-dapp-template/package.json
@@ -11,6 +11,7 @@
     "move:upgrade": "node ./scripts/move/upgrade",
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy":"vercel",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "_fmt": "prettier 'frontend/**/*.ts'",
@@ -69,6 +70,7 @@
     "vite": "^5.2.0",
     "vite-plugin-node-polyfills": "^0.21.0",
     "vite-plugin-notifier": "^0.1.5",
-    "prettier": "^3.3.2"
+    "prettier": "^3.3.2",
+    "vercel": "^35.2.4"
   }
 }

--- a/templates/token-minting-dapp-template/vite.config.ts
+++ b/templates/token-minting-dapp-template/vite.config.ts
@@ -5,7 +5,7 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 export default defineConfig({
   build: {
-    outDir: "build",
+    outDir: "dist",
   },
   server: {
     open: true,

--- a/templates/token-staking-dapp-template/README.md
+++ b/templates/token-staking-dapp-template/README.md
@@ -48,5 +48,6 @@ Some commands are built-in the template and can be ran as a npm script, for exam
 - `npm run move:publish` - a command to publish the Move contract
 - `npm run move:test` - a command to run Move unit tests
 - `npm run move:compile` - a command to compile the Move contract
+- `npm run deploy` - a command to deploy the dapp to Vercel
 
 For all other available CLI commands, can run `npx aptos` and see a list of all available commands.

--- a/templates/token-staking-dapp-template/package.json
+++ b/templates/token-staking-dapp-template/package.json
@@ -11,6 +11,7 @@
     "move:upgrade": "node ./scripts/move/upgrade",
     "dev": "vite",
     "build": "tsc && vite build",
+    "deploy": "vercel",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "_fmt": "prettier 'frontend/**/*.ts'",
@@ -56,6 +57,7 @@
     "tree-kill": "1.2.2",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
-    "vite-plugin-notifier": "^0.1.5"
+    "vite-plugin-notifier": "^0.1.5",
+    "vercel": "^35.2.4"
   }
 }

--- a/templates/token-staking-dapp-template/vite.config.ts
+++ b/templates/token-staking-dapp-template/vite.config.ts
@@ -4,14 +4,12 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   build: {
-    outDir: "build",
+    outDir: "dist",
   },
   server: {
     open: true,
   },
-  plugins: [
-    react()
-  ],
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./frontend"),


### PR DESCRIPTION
This PR adds `npm run deploy` command to easily deploy a static site to Vercel