### PR TITLE
Add a Google wallet not supported warning on file uploading page

### DIFF
--- a/templates/nft-minting-dapp-template/frontend/pages/CreateCollection.tsx
+++ b/templates/nft-minting-dapp-template/frontend/pages/CreateCollection.tsx
@@ -1,6 +1,6 @@
 // External packages
 import { useRef, useState } from "react";
-import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { isAptosConnectWallet, useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Link, useNavigate } from "react-router-dom";
 // Internal utils
 import { aptosClient } from "@/utils/aptosClient";
@@ -23,7 +23,7 @@ import { createCollection } from "@/entry-functions/create_collection";
 export function CreateCollection() {
   // Wallet Adapter provider
   const aptosWallet = useWallet();
-  const { account, signAndSubmitTransaction } = useWallet();
+  const { account, wallet, signAndSubmitTransaction } = useWallet();
 
   // If we are on Production mode, redierct to the public mint page
   const navigate = useNavigate();
@@ -143,6 +143,12 @@ export function CreateCollection() {
             </WarningAlert>
           )}
 
+{wallet && isAptosConnectWallet(wallet) && (
+            <WarningAlert title="Wallet not supported">
+              Google account is not supported when creating a NFT collection. Please use a different wallet.
+            </WarningAlert>
+          )}
+
           <UploadSpinner on={isUploading} />
 
           <Card>
@@ -166,7 +172,7 @@ export function CreateCollection() {
                   className="hidden"
                   ref={inputRef}
                   id="upload"
-                  disabled={isUploading || !account}
+                  disabled={isUploading || !account || !wallet || isAptosConnectWallet(wallet)}
                   webkitdirectory="true"
                   multiple
                   type="file"

--- a/templates/token-minting-dapp-template/frontend/pages/CreateFungibleAsset.tsx
+++ b/templates/token-minting-dapp-template/frontend/pages/CreateFungibleAsset.tsx
@@ -1,4 +1,4 @@
-import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { isAptosConnectWallet, useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useRef, useState } from "react";
 // Internal components
@@ -22,7 +22,7 @@ import { createAsset } from "@/entry-functions/create_asset";
 export function CreateFungibleAsset() {
   // Wallet Adapter provider
   const aptosWallet = useWallet();
-  const { account, signAndSubmitTransaction } = useWallet();
+  const { account, wallet, signAndSubmitTransaction } = useWallet();
 
   // If we are on Production mode, redierct to the public mint page
   const navigate = useNavigate();
@@ -111,6 +111,13 @@ export function CreateFungibleAsset() {
             </WarningAlert>
           )}
 
+{wallet && isAptosConnectWallet(wallet) && (
+            <WarningAlert title="Wallet not supported">
+              Google account is not supported when creating a Token. Please use a different wallet.
+            </WarningAlert>
+          )}
+
+
           <UploadSpinner on={isUploading} />
 
           <Card>
@@ -132,7 +139,7 @@ export function CreateFungibleAsset() {
                   </Label>
                 )}
                 <Input
-                  disabled={isUploading || !account}
+                  disabled={isUploading || !account || !wallet || isAptosConnectWallet(wallet)}
                   type="file"
                   className="hidden"
                   ref={inputRef}


### PR DESCRIPTION
Since AptosConnect is not yet supported by Irys (which is the service CAD uses to upload files with) we add a Warning on only the "create" page for nft and token templates for when the dev is connected with a Google wallet