### PR TITLE
Fix token up to mint and add a flag to enable/disable mint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,5 @@ node_modules
 .idea
 .env
 .aptos
-
 package-lock.json
-
-templates/*/contract/build
-templates/*/build
-
-examples/*/move/build
-examples/*/build
+build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to the create-aptos-dapp tool will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-# Unreleased
-
-- Add new view function to minting template that returns user mint balance and display that on UI
-- Add a minting enabled / disabled flag to nft minting template and token minting template
-
 # 0.0.24 (2024-09-04)
 
 - Code cleanup, always use env var from constants
@@ -15,6 +10,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Rename template `move` folder to `contract`
 - Update next steps instructions when generating a template to follow README file
 - Make sure each template README file mentions the template doc on aptos.dev
+- Add new view function to minting template that returns user mint balance and display that on UI
+- Add a minting enabled / disabled flag to nft minting template and token minting template
 
 # 0.0.23 (2024-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Move `collection_address` and `fa_address` from `config.ts` to the `.env` file in the minting templates
 - Rename template `move` folder to `contract`
 - Update next steps instructions when generating a template to follow README file
-- Make sure each temlpate README file mentions the template doc on aptos.dev
+- Make sure each template README file mentions the template doc on aptos.dev
 
 # 0.0.23 (2024-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 # Unreleased
 
+- Add new view function to minting template that returns user mint balance and display that on UI
+
 # 0.0.24 (2024-09-04)
 
 - Code cleanup, always use env var from constants
@@ -18,7 +20,6 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Add Token Staking template walkthrough video
 - Change Token minting template walkthrough video
 - Support a `--verbose` flag to run wizard with std out
-- Add new view function to minting template that returns user mint balance and display that on UI
 
 # 0.0.22 (2024-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Add Token Staking template walkthrough video
 - Change Token minting template walkthrough video
 - Support a `--verbose` flag to run wizard with std out
+- Add new view function to minting template that returns user mint balance and display that on UI
 
 # 0.0.22 (2024-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 # Unreleased
 
 - Add new view function to minting template that returns user mint balance and display that on UI
+- Add a minting enabled / disabled flag to nft minting template and token minting template
 
 # 0.0.24 (2024-09-04)
 

--- a/templates/nft-minting-dapp-template/contract/sources/launchpad.move
+++ b/templates/nft-minting-dapp-template/contract/sources/launchpad.move
@@ -349,7 +349,7 @@ module launchpad_addr::launchpad {
 
     #[view]
     /// Get contract pending admin
-    public fun get_pendingadmin(): Option<address> acquires Config {
+    public fun get_pending_admin(): Option<address> acquires Config {
         let config = borrow_global<Config>(@launchpad_addr);
         config.pending_admin_addr
     }
@@ -378,6 +378,18 @@ module launchpad_addr::launchpad {
         let collection_config = borrow_global<CollectionConfig>(object::object_address(&collection_obj));
         let fee = *simple_map::borrow(&collection_config.mint_fee_per_nft_by_stages, &stage_name);
         amount * fee
+    }
+
+    #[view]
+    /// Get mint balance for the stage, i.e. how many NFT user can mint
+    /// e.g. If the mint limit is 1, user has already minted 1, balance is 0
+    public fun get_mint_balance(collection_obj: Object<Collection>, stage_name: String, user_addr: address): u64 {
+        let stage_idx = mint_stage::find_mint_stage_index_by_name(collection_obj, stage_name);
+        if (stage_name == string::utf8(ALLOWLIST_MINT_STAGE_CATEGORY)) {
+            mint_stage::allowlist_balance(collection_obj, stage_idx, user_addr)
+        } else {
+            mint_stage::public_stage_with_limit_user_balance(collection_obj, stage_idx, user_addr)
+        }
     }
 
     #[view]

--- a/templates/nft-minting-dapp-template/contract/sources/launchpad.move
+++ b/templates/nft-minting-dapp-template/contract/sources/launchpad.move
@@ -40,6 +40,10 @@ module launchpad_addr::launchpad {
     const EEND_TIME_MUST_BE_SET_FOR_STAGE: u64 = 9;
     /// Mint limit per address must be set for stage
     const EMINT_LIMIT_PER_ADDR_MUST_BE_SET_FOR_STAGE: u64 = 10;
+    /// Only admin can update mint enabled
+    const EONLY_ADMIN_CAN_UPDATE_MINT_ENABLED: u64 = 11;
+    /// Mint is disabled
+    const EMINT_IS_DISABLED: u64 = 12;
 
     /// Default to mint 0 amount to creator when creating collection
     const DEFAULT_PRE_MINT_AMOUNT: u64 = 0;
@@ -94,7 +98,6 @@ module launchpad_addr::launchpad {
     /// We need this object to own the collection object instead of contract directly owns the collection object
     /// This helps us avoid address collision when we create multiple collections with same name
     struct CollectionOwnerObjConfig has key {
-        // Only thing it stores is the link to collection object
         collection_obj: Object<Collection>,
         extend_ref: object::ExtendRef,
     }
@@ -103,7 +106,9 @@ module launchpad_addr::launchpad {
     struct CollectionConfig has key {
         // Key is stage, value is mint fee denomination
         mint_fee_per_nft_by_stages: SimpleMap<String, u64>,
+        mint_enabled: bool,
         collection_owner_obj: Object<CollectionOwnerObjConfig>,
+        extend_ref: object::ExtendRef,
     }
 
     /// Global per contract
@@ -160,6 +165,16 @@ module launchpad_addr::launchpad {
         assert!(config.pending_admin_addr == option::some(sender_addr), ENOT_PENDING_ADMIN);
         config.admin_addr = sender_addr;
         config.pending_admin_addr = option::none();
+    }
+
+    /// Update mint enabled
+    public entry fun update_mint_enabled(sender: &signer, collection_obj: Object<Collection>, enabled: bool) acquires Config, CollectionConfig {
+        let sender_addr = signer::address_of(sender);
+        let config = borrow_global_mut<Config>(@launchpad_addr);
+        assert!(is_admin(config, sender_addr), EONLY_ADMIN_CAN_UPDATE_MINT_ENABLED);
+        let collection_obj_addr = object::object_address(&collection_obj);
+        let collection_config = borrow_global_mut<CollectionConfig>(collection_obj_addr);
+        collection_config.mint_enabled = enabled;
     }
 
     /// Update mint fee collector address
@@ -229,6 +244,8 @@ module launchpad_addr::launchpad {
         let collection_owner_obj = object::object_from_constructor_ref(collection_owner_obj_constructor_ref);
         move_to(collection_obj_signer, CollectionConfig {
             mint_fee_per_nft_by_stages: simple_map::new(),
+            mint_enabled: true,
+            extend_ref: object::generate_extend_ref(collection_obj_constructor_ref),
             collection_owner_obj,
         });
 
@@ -307,6 +324,7 @@ module launchpad_addr::launchpad {
         collection_obj: Object<Collection>,
         amount: u64,
     ) acquires CollectionConfig, CollectionOwnerObjConfig, Config {
+        assert!(is_mint_enabled(collection_obj), EMINT_IS_DISABLED);
         let sender_addr = signer::address_of(sender);
 
         let stage_idx = &mint_stage::execute_earliest_stage(sender, collection_obj, amount);
@@ -366,6 +384,14 @@ module launchpad_addr::launchpad {
     public fun get_registry(): vector<Object<Collection>> acquires Registry {
         let registry = borrow_global<Registry>(@launchpad_addr);
         registry.collection_objects
+    }
+
+    #[view]
+    /// Is mint enabled for the collection
+    public fun is_mint_enabled(collection_obj: Object<Collection>): bool acquires CollectionConfig {
+        let collection_addr = object::object_address(&collection_obj);
+        let collection_config = borrow_global<CollectionConfig>(collection_addr);
+        collection_config.mint_enabled
     }
 
     #[view]

--- a/templates/nft-minting-dapp-template/contract/sources/launchpad.move
+++ b/templates/nft-minting-dapp-template/contract/sources/launchpad.move
@@ -44,6 +44,8 @@ module launchpad_addr::launchpad {
     const EONLY_ADMIN_CAN_UPDATE_MINT_ENABLED: u64 = 11;
     /// Mint is disabled
     const EMINT_IS_DISABLED: u64 = 12;
+    /// Cannot mint 0 amount
+    const ECANNOT_MINT_ZERO: u64 = 13;
 
     /// Default to mint 0 amount to creator when creating collection
     const DEFAULT_PRE_MINT_AMOUNT: u64 = 0;
@@ -324,6 +326,7 @@ module launchpad_addr::launchpad {
         collection_obj: Object<Collection>,
         amount: u64,
     ) acquires CollectionConfig, CollectionOwnerObjConfig, Config {
+        assert!(amount > 0, ECANNOT_MINT_ZERO);
         assert!(is_mint_enabled(collection_obj), EMINT_IS_DISABLED);
         let sender_addr = signer::address_of(sender);
 

--- a/templates/nft-minting-dapp-template/frontend/hooks/useGetCollectionData.ts
+++ b/templates/nft-minting-dapp-template/frontend/hooks/useGetCollectionData.ts
@@ -6,6 +6,7 @@ import { getActiveOrNextMintStage } from "@/view-functions/getActiveOrNextMintSt
 import { getMintStageStartAndEndTime } from "@/view-functions/getMintStageStartAndEndTime";
 import { getUserMintBalance } from "@/view-functions/getUserMintBalance";
 import { COLLECTION_ADDRESS } from "@/constants";
+import { getMintEnabled } from "@/view-functions/getMintEnabled";
 
 export interface Token {
   token_name: string;
@@ -128,6 +129,7 @@ export function useGetCollectionData(collection_address: string = COLLECTION_ADD
           account == null
             ? 0
             : await getUserMintBalance({ user_address: account.address, collection_address, mint_stage });
+        const isMintEnabled = await getMintEnabled({ collection_address });
 
         return {
           maxSupply: collection.max_supply ?? 0,
@@ -138,7 +140,10 @@ export function useGetCollectionData(collection_address: string = COLLECTION_ADD
           endDate,
           startDate,
           isMintActive:
-            new Date() >= startDate && new Date() <= endDate && collection.max_supply > collection.current_supply,
+            isMintEnabled &&
+            new Date() >= startDate &&
+            new Date() <= endDate &&
+            collection.max_supply > collection.current_supply,
           isMintInfinite,
         } satisfies MintData;
       } catch (error) {

--- a/templates/nft-minting-dapp-template/frontend/hooks/useGetCollectionData.ts
+++ b/templates/nft-minting-dapp-template/frontend/hooks/useGetCollectionData.ts
@@ -1,11 +1,11 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { useQuery } from "@tanstack/react-query";
 
-import { config } from "@/config";
 import { aptosClient } from "@/utils/aptosClient";
 import { getActiveOrNextMintStage } from "@/view-functions/getActiveOrNextMintStage";
 import { getMintStageStartAndEndTime } from "@/view-functions/getMintStageStartAndEndTime";
 import { getUserMintBalance } from "@/view-functions/getUserMintBalance";
+import { COLLECTION_ADDRESS } from "@/constants";
 
 export interface Token {
   token_name: string;
@@ -56,7 +56,7 @@ interface MintData {
   isMintInfinite: boolean;
 }
 
-export function useGetCollectionData(collection_id: string = config.collection_id) {
+export function useGetCollectionData(collection_address: string = COLLECTION_ADDRESS) {
   const { account } = useWallet();
 
   return useQuery({
@@ -103,7 +103,7 @@ export function useGetCollectionData(collection_id: string = config.collection_i
         const collection = res.current_collections_v2[0];
         if (!collection) return null;
 
-        const mintStageRes = await getActiveOrNextMintStage({ collection_id });
+        const mintStageRes = await getActiveOrNextMintStage({ collection_address });
         // Only return collection data if no mint stage is found
         if (mintStageRes.length === 0) {
           return {
@@ -120,9 +120,14 @@ export function useGetCollectionData(collection_id: string = config.collection_i
         }
 
         const mint_stage = mintStageRes[0];
-        const { startDate, endDate, isMintInfinite } = await getMintStageStartAndEndTime({ collection_id, mint_stage });
+        const { startDate, endDate, isMintInfinite } = await getMintStageStartAndEndTime({
+          collection_address,
+          mint_stage,
+        });
         const userMintBalance =
-          account == null ? 0 : await getUserMintBalance({ user_address: account.address, collection_id, mint_stage });
+          account == null
+            ? 0
+            : await getUserMintBalance({ user_address: account.address, collection_address, mint_stage });
 
         return {
           maxSupply: collection.max_supply ?? 0,

--- a/templates/nft-minting-dapp-template/frontend/hooks/useGetCollections.tsx
+++ b/templates/nft-minting-dapp-template/frontend/hooks/useGetCollections.tsx
@@ -2,7 +2,7 @@ import { AccountAddress, GetCollectionDataResponse } from "@aptos-labs/ts-sdk";
 import { useState, useEffect } from "react";
 
 import { aptosClient } from "@/utils/aptosClient";
-import { MODULE_ADDRESS } from "@/constants";
+import { getRegistry } from "@/view-functions/getRegistry";
 
 /**
  * A react hook to get all collections under the current contract.
@@ -30,15 +30,6 @@ export function useGetCollections() {
 
   return collections;
 }
-
-const getRegistry = async () => {
-  const registry = await aptosClient().view<[[{ inner: string }]]>({
-    payload: {
-      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_registry`,
-    },
-  });
-  return registry[0];
-};
 
 const getObjects = async (registry: [{ inner: string }]) => {
   const objects = await Promise.all(

--- a/templates/nft-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/nft-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -34,7 +34,8 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
   const { account, signAndSubmitTransaction } = useWallet();
   const [nftCount, setNftCount] = useState(1);
 
-  const { collection, totalMinted = 0, maxSupply = 1 } = data ?? {};
+  const { userMintBalance = 0, collection, totalMinted = 0, maxSupply = 1 } = data ?? {};
+  const mintUpTo = Math.min(userMintBalance, maxSupply - totalMinted);
 
   const mintNft = async (e: FormEvent) => {
     e.preventDefault();
@@ -77,8 +78,11 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
                 Mint
               </Button>
             </form>
-
-            <div className="flex flex-col gap-2 w-full md:basis-1/2">
+            <div className="flex flex-col basis-1/3">
+              <p className="label-sm">You can mint up to</p>
+              <p className="body-md">{mintUpTo > 1 ? `${mintUpTo} NFTs` : `${mintUpTo} NFT`}</p>
+            </div>
+            <div className="flex flex-col gap-2 w-full md:basis-1/3">
               <p className="label-sm text-secondary-text">
                 {clampNumber(totalMinted)} / {clampNumber(maxSupply)} Minted
               </p>

--- a/templates/nft-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/nft-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -78,7 +78,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
                 Mint
               </Button>
             </form>
-            <div className="flex flex-col basis-1/3">
+            <div className="flex flex-col gap-2 w-full md:basis-1/3">
               <p className="label-sm">You can mint up to</p>
               <p className="body-md">{mintUpTo > 1 ? `${mintUpTo} NFTs` : `${mintUpTo} NFT`}</p>
             </div>

--- a/templates/nft-minting-dapp-template/frontend/utils/Irys.ts
+++ b/templates/nft-minting-dapp-template/frontend/utils/Irys.ts
@@ -1,6 +1,7 @@
 import { WebIrys } from "@irys/sdk";
 import { WalletContextState } from "@aptos-labs/wallet-adapter-react";
 import { getAccountAPTBalance } from "@/view-functions/getAccountAPTBalance";
+import { NETWORK } from "@/constants";
 
 const getWebIrys = async (aptosWallet: WalletContextState) => {
   const network = NETWORK === "testnet" ? "devnet" : "mainnet"; // Irys network

--- a/templates/nft-minting-dapp-template/frontend/utils/Irys.ts
+++ b/templates/nft-minting-dapp-template/frontend/utils/Irys.ts
@@ -1,7 +1,6 @@
 import { WebIrys } from "@irys/sdk";
 import { WalletContextState } from "@aptos-labs/wallet-adapter-react";
-import { accountAPTBalance } from "@/view-functions/accountBalance";
-import { NETWORK } from "@/constants";
+import { getAccountAPTBalance } from "@/view-functions/getAccountAPTBalance";
 
 const getWebIrys = async (aptosWallet: WalletContextState) => {
   const network = NETWORK === "testnet" ? "devnet" : "mainnet"; // Irys network
@@ -27,7 +26,7 @@ export const checkIfFund = async (aptosWallet: WalletContextState, files: File[]
   // 4. if balance is not enough,  check the payer balance
   const currentAccountAddress = await aptosWallet.account!.address;
 
-  const currentAccountBalance = await accountAPTBalance({ accountAddress: currentAccountAddress });
+  const currentAccountBalance = await getAccountAPTBalance({ accountAddress: currentAccountAddress });
 
   // 5. if payer balance > the amount based on the estimation, fund the irys node irys.fund, then upload
   if (currentAccountBalance > costToUpload.toNumber()) {

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getAccountAPTBalance.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getAccountAPTBalance.ts
@@ -1,10 +1,10 @@
 import { aptosClient } from "@/utils/aptosClient";
 
-export type AccountAPTBalanceArguments = {
+type GetAccountAPTBalanceArguments = {
   accountAddress: string;
 };
 
-export const accountAPTBalance = async (args: AccountAPTBalanceArguments): Promise<number> => {
+export const getAccountAPTBalance = async (args: GetAccountAPTBalanceArguments): Promise<number> => {
   const { accountAddress } = args;
   const balance = await aptosClient().view<[number]>({
     payload: {

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getActiveOrNextMintStage.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getActiveOrNextMintStage.ts
@@ -3,14 +3,14 @@ import { aptosClient } from "@/utils/aptosClient";
 import { MODULE_ADDRESS } from "@/constants";
 
 type GetRegistryArguments = {
-  collection_id: string;
+  collection_address: string;
 };
 
-export const getActiveOrNextMintStage = async ({ collection_id }: GetRegistryArguments) => {
+export const getActiveOrNextMintStage = async ({ collection_address }: GetRegistryArguments) => {
   const mintStageRes = await aptosClient().view<[{ vec: [string] | [] }]>({
     payload: {
       function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_active_or_next_mint_stage`,
-      functionArguments: [collection_id],
+      functionArguments: [collection_address],
     },
   });
   return mintStageRes[0].vec;

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getActiveOrNextMintStage.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getActiveOrNextMintStage.ts
@@ -1,0 +1,17 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetRegistryArguments = {
+  collection_id: string;
+};
+
+export const getActiveOrNextMintStage = async ({ collection_id }: GetRegistryArguments) => {
+  const mintStageRes = await aptosClient().view<[{ vec: [string] | [] }]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_active_or_next_mint_stage`,
+      functionArguments: [collection_id],
+    },
+  });
+  return mintStageRes[0].vec;
+};

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getMintEnabled.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getMintEnabled.ts
@@ -1,0 +1,18 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetMintEnabledArguments = {
+  collection_address: string;
+};
+
+export const getMintEnabled = async ({ collection_address }: GetMintEnabledArguments) => {
+  const mintEnabled = await aptosClient().view<[boolean]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::is_mint_enabled`,
+      functionArguments: [collection_address],
+    },
+  });
+
+  return mintEnabled[0];
+};

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getMintStageStartAndEndTime.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getMintStageStartAndEndTime.ts
@@ -1,0 +1,28 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetMintStageStartAndEndTimeArguments = {
+  collection_id: string;
+  mint_stage: string;
+};
+
+export const getMintStageStartAndEndTime = async ({
+  collection_id,
+  mint_stage,
+}: GetMintStageStartAndEndTimeArguments) => {
+  const startAndEndRes = await aptosClient().view<[string, string]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_stage_start_and_end_time`,
+      functionArguments: [collection_id, mint_stage],
+    },
+  });
+
+  const [start, end] = startAndEndRes;
+  return {
+    startDate: new Date(parseInt(start, 10) * 1000),
+    endDate: new Date(parseInt(end, 10) * 1000),
+    // isMintInfinite is true if the mint stage is 100 years later
+    isMintInfinite: parseInt(end, 10) === parseInt(start, 10) + 100 * 365 * 24 * 60 * 60,
+  };
+};

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getMintStageStartAndEndTime.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getMintStageStartAndEndTime.ts
@@ -3,18 +3,18 @@ import { aptosClient } from "@/utils/aptosClient";
 import { MODULE_ADDRESS } from "@/constants";
 
 type GetMintStageStartAndEndTimeArguments = {
-  collection_id: string;
+  collection_address: string;
   mint_stage: string;
 };
 
 export const getMintStageStartAndEndTime = async ({
-  collection_id,
+  collection_address,
   mint_stage,
 }: GetMintStageStartAndEndTimeArguments) => {
   const startAndEndRes = await aptosClient().view<[string, string]>({
     payload: {
       function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_stage_start_and_end_time`,
-      functionArguments: [collection_id, mint_stage],
+      functionArguments: [collection_address, mint_stage],
     },
   });
 

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getRegistry.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getRegistry.ts
@@ -1,0 +1,12 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+export const getRegistry = async () => {
+  const registry = await aptosClient().view<[[{ inner: string }]]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_registry`,
+    },
+  });
+  return registry[0];
+};

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
@@ -3,16 +3,20 @@ import { aptosClient } from "@/utils/aptosClient";
 import { MODULE_ADDRESS } from "@/constants";
 
 type GetUserMintBalanceArguments = {
-  collection_id: string;
+  collection_address: string;
   mint_stage: string;
   user_address: string;
 };
 
-export const getUserMintBalance = async ({ collection_id, mint_stage, user_address }: GetUserMintBalanceArguments) => {
+export const getUserMintBalance = async ({
+  collection_address,
+  mint_stage,
+  user_address,
+}: GetUserMintBalanceArguments) => {
   const userMintedAmount = await aptosClient().view<[string]>({
     payload: {
       function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_balance`,
-      functionArguments: [collection_id, mint_stage, user_address],
+      functionArguments: [collection_address, mint_stage, user_address],
     },
   });
 

--- a/templates/nft-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
+++ b/templates/nft-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
@@ -1,0 +1,20 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetUserMintBalanceArguments = {
+  collection_id: string;
+  mint_stage: string;
+  user_address: string;
+};
+
+export const getUserMintBalance = async ({ collection_id, mint_stage, user_address }: GetUserMintBalanceArguments) => {
+  const userMintedAmount = await aptosClient().view<[string]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_balance`,
+      functionArguments: [collection_id, mint_stage, user_address],
+    },
+  });
+
+  return Number(userMintedAmount[0]);
+};

--- a/templates/token-minting-dapp-template/contract/sources/launchpad.move
+++ b/templates/token-minting-dapp-template/contract/sources/launchpad.move
@@ -30,6 +30,8 @@ module launchpad_addr::launchpad {
     const EONLY_ADMIN_CAN_UPDATE_MINT_ENABLED: u64 = 8;
     /// Mint is disabled
     const EMINT_IS_DISABLED: u64 = 9;
+    /// Cannot mint 0 amount
+    const ECANNOT_MINT_ZERO: u64 = 10;
 
     /// Default to mint 0 amount to creator when creating FA
     const DEFAULT_PRE_MINT_AMOUNT: u64 = 0;
@@ -271,6 +273,7 @@ module launchpad_addr::launchpad {
         fa_obj: Object<Metadata>,
         amount: u64
     ) acquires FAController, FAConfig, Config {
+        assert!(amount > 0, ECANNOT_MINT_ZERO);
         assert!(is_mint_enabled(fa_obj), EMINT_IS_DISABLED);
         let sender_addr = signer::address_of(sender);
         check_mint_limit_and_update_mint_tracker(sender_addr, fa_obj, amount);
@@ -404,7 +407,7 @@ module launchpad_addr::launchpad {
         if (option::is_some(&mint_limit)) {
             let mint_balance = get_mint_balance(fa_obj, sender);
             assert!(
-                mint_balance > 0,
+                mint_balance <= amount,
                 EMINT_LIMIT_REACHED,
             );
             let fa_config = borrow_global_mut<FAConfig>(object::object_address(&fa_obj));

--- a/templates/token-minting-dapp-template/contract/sources/launchpad.move
+++ b/templates/token-minting-dapp-template/contract/sources/launchpad.move
@@ -407,7 +407,7 @@ module launchpad_addr::launchpad {
         if (option::is_some(&mint_limit)) {
             let mint_balance = get_mint_balance(fa_obj, sender);
             assert!(
-                mint_balance <= amount,
+                mint_balance >= amount,
                 EMINT_LIMIT_REACHED,
             );
             let fa_config = borrow_global_mut<FAConfig>(object::object_address(&fa_obj));

--- a/templates/token-minting-dapp-template/contract/tests/test_end_to_end.move
+++ b/templates/token-minting-dapp-template/contract/tests/test_end_to_end.move
@@ -75,4 +75,41 @@ module launchpad_addr::test_end_to_end {
         coin::destroy_burn_cap(burn_cap);
         coin::destroy_mint_cap(mint_cap);
     }
+
+    #[test(aptos_framework = @0x1, sender = @launchpad_addr)]
+    #[expected_failure(abort_code = 9, location = launchpad)]
+    fun test_mint_disabled(
+        aptos_framework: &signer,
+        sender: &signer,
+    ) {
+        let (burn_cap, mint_cap) = aptos_coin::initialize_for_test(aptos_framework);
+
+        launchpad::init_module_for_test(sender);
+
+        launchpad::create_fa(
+            sender,
+            option::some(1000),
+            string::utf8(b"FA1"),
+            string::utf8(b"FA1"),
+            2,
+            string::utf8(b"icon_url"),
+            string::utf8(b"project_url"),
+            option::none(),
+            option::none(),
+            option::some(500)
+        );
+        let registry = launchpad::get_registry();
+        let fa_1 = *vector::borrow(&registry, vector::length(&registry) - 1);
+        assert!(launchpad::is_mint_enabled(fa_1), 1);
+
+        launchpad::mint_fa(sender, fa_1, 20);
+
+        launchpad::update_mint_enabled(sender, fa_1, false);
+        assert!(!launchpad::is_mint_enabled(fa_1), 2);
+
+        launchpad::mint_fa(sender, fa_1, 20);
+
+        coin::destroy_burn_cap(burn_cap);
+        coin::destroy_mint_cap(mint_cap);
+    }
 }

--- a/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
+++ b/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
@@ -5,6 +5,7 @@ import { aptosClient } from "@/utils/aptosClient";
 import { convertAmountFromOnChainToHumanReadable } from "@/utils/helpers";
 // Internal constants
 import { getUserMintBalance } from "@/view-functions/getUserMintBalance";
+import { FA_ADDRESS } from "@/constants";
 
 export interface FungibleAsset {
   maximum_v2: number;

--- a/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
+++ b/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
@@ -1,11 +1,10 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { AccountAddress } from "@aptos-labs/ts-sdk";
 import { useQuery } from "@tanstack/react-query";
 // Internal utils
 import { aptosClient } from "@/utils/aptosClient";
 import { convertAmountFromOnChainToHumanReadable } from "@/utils/helpers";
 // Internal constants
-import { FA_ADDRESS, MODULE_ADDRESS } from "@/constants";
+import { getUserMintBalance } from "@/view-functions/getUserMintBalance";
 
 export interface FungibleAsset {
   maximum_v2: number;
@@ -37,17 +36,6 @@ interface MintData {
   userMintBalance: number;
   asset: FungibleAsset;
   isMintActive: boolean;
-}
-
-async function getUserMintBalance(user_address: string, fa_address: string): Promise<number> {
-  const userMintedAmount = await aptosClient().view<[string]>({
-    payload: {
-      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_balance`,
-      functionArguments: [fa_address, user_address],
-    },
-  });
-
-  return Number(userMintedAmount[0]);
 }
 
 /**
@@ -108,7 +96,7 @@ export function useGetAssetData(fa_address: string = FA_ADDRESS) {
           currentSupply: convertAmountFromOnChainToHumanReadable(asset.supply_v2 ?? 0, asset.decimals),
           uniqueHolders: res.current_fungible_asset_balances_aggregate.aggregate.count ?? 0,
           userMintBalance: convertAmountFromOnChainToHumanReadable(
-            account == null ? 0 : await getUserMintBalance(account.address, fa_address),
+            account == null ? 0 : await getUserMintBalance({ user_address: account.address, fa_address }),
             asset.decimals,
           ),
           yourBalance: convertAmountFromOnChainToHumanReadable(

--- a/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
+++ b/templates/token-minting-dapp-template/frontend/hooks/useGetAssetData.ts
@@ -6,6 +6,7 @@ import { convertAmountFromOnChainToHumanReadable } from "@/utils/helpers";
 // Internal constants
 import { getUserMintBalance } from "@/view-functions/getUserMintBalance";
 import { FA_ADDRESS } from "@/constants";
+import { getMintEnabled } from "@/view-functions/getMintEnabled";
 
 export interface FungibleAsset {
   maximum_v2: number;
@@ -91,6 +92,8 @@ export function useGetAssetData(fa_address: string = FA_ADDRESS) {
         const asset = res.fungible_asset_metadata[0];
         if (!asset) return null;
 
+        const isMintEnabled = await getMintEnabled({ fa_address });
+
         return {
           asset,
           maxSupply: convertAmountFromOnChainToHumanReadable(asset.maximum_v2 ?? 0, asset.decimals),
@@ -104,7 +107,7 @@ export function useGetAssetData(fa_address: string = FA_ADDRESS) {
             res.current_fungible_asset_balances[0]?.amount ?? 0,
             asset.decimals,
           ),
-          isMintActive: asset.maximum_v2 > asset.supply_v2,
+          isMintActive: isMintEnabled && asset.maximum_v2 > asset.supply_v2,
         } satisfies MintData;
       } catch (error) {
         console.error(error);

--- a/templates/token-minting-dapp-template/frontend/hooks/useGetAssetMetadata.tsx
+++ b/templates/token-minting-dapp-template/frontend/hooks/useGetAssetMetadata.tsx
@@ -2,7 +2,7 @@ import { AccountAddress, GetFungibleAssetMetadataResponse } from "@aptos-labs/ts
 import { useState, useEffect } from "react";
 // Internal utils
 import { aptosClient } from "@/utils/aptosClient";
-import { MODULE_ADDRESS } from "@/constants";
+import { getRegistry } from "@/view-functions/getRegistry";
 
 /**
  * A react hook to get fungible asset metadatas.
@@ -29,15 +29,6 @@ export function useGetAssetMetadata() {
 
   return fas;
 }
-
-const getRegistry = async () => {
-  const registry = await aptosClient().view<[[{ inner: string }]]>({
-    payload: {
-      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_registry`,
-    },
-  });
-  return registry[0];
-};
 
 const getObjects = async (registry: [{ inner: string }]) => {
   const objects = await Promise.all(

--- a/templates/token-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
+++ b/templates/token-minting-dapp-template/frontend/pages/Mint/components/HeroSection.tsx
@@ -33,7 +33,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
   const [assetCount, setAssetCount] = useState<string>("1");
   const [error, setError] = useState<string | null>(null);
 
-  const { asset, totalAbleToMint = 0, yourBalance = 0, maxSupply = 0, currentSupply = 0 } = data ?? {};
+  const { asset, userMintBalance = 0, yourBalance = 0, maxSupply = 0, currentSupply = 0 } = data ?? {};
 
   const mintFA = async (e: FormEvent) => {
     e.preventDefault();
@@ -101,7 +101,7 @@ export const HeroSection: React.FC<HeroSectionProps> = () => {
             <div className="flex flex-col basis-1/3">
               <p className="label-sm">You can mint up to</p>
               <p className="body-md">
-                {Math.min(totalAbleToMint, maxSupply - currentSupply)} {asset?.symbol}
+                {Math.min(userMintBalance, maxSupply - currentSupply)} {asset?.symbol}
               </p>
             </div>
 

--- a/templates/token-minting-dapp-template/frontend/utils/Irys.ts
+++ b/templates/token-minting-dapp-template/frontend/utils/Irys.ts
@@ -1,6 +1,6 @@
 import { WebIrys } from "@irys/sdk";
 import { WalletContextState } from "@aptos-labs/wallet-adapter-react";
-import { accountAPTBalance } from "@/view-functions/accountBalance";
+import { getAccountAPTBalance } from "@/view-functions/getAccountAPTBalance";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getWebIrys = async (aptosWallet: any) => {
@@ -34,7 +34,7 @@ export const checkIfFund = async (aptosWallet: WalletContextState, fileSize: num
   // 4. if balance is not enough,  check the payer balance
   const currentAccountAddress = await aptosWallet.account!.address;
 
-  const currentAccountBalance = await accountAPTBalance({ accountAddress: currentAccountAddress });
+  const currentAccountBalance = await getAccountAPTBalance({ accountAddress: currentAccountAddress });
 
   // 5. if payer balance > the amount based on the estimation, fund the irys node irys.fund, then upload
   if (currentAccountBalance > costToUpload.toNumber()) {

--- a/templates/token-minting-dapp-template/frontend/view-functions/getAccountAPTBalance.ts
+++ b/templates/token-minting-dapp-template/frontend/view-functions/getAccountAPTBalance.ts
@@ -1,10 +1,10 @@
 import { aptosClient } from "@/utils/aptosClient";
 
-export type AccountAPTBalanceArguments = {
+export type GetAccountAPTBalanceArguments = {
   accountAddress: string;
 };
 
-export const accountAPTBalance = async (args: AccountAPTBalanceArguments): Promise<number> => {
+export const getAccountAPTBalance = async (args: GetAccountAPTBalanceArguments): Promise<number> => {
   const { accountAddress } = args;
   const balance = await aptosClient().view<[number]>({
     payload: {

--- a/templates/token-minting-dapp-template/frontend/view-functions/getMintEnabled.ts
+++ b/templates/token-minting-dapp-template/frontend/view-functions/getMintEnabled.ts
@@ -1,0 +1,18 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetMintEnabledArguments = {
+  fa_address: string;
+};
+
+export const getMintEnabled = async ({ fa_address }: GetMintEnabledArguments) => {
+  const mintEnabled = await aptosClient().view<[boolean]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::is_mint_enabled`,
+      functionArguments: [fa_address],
+    },
+  });
+
+  return mintEnabled[0];
+};

--- a/templates/token-minting-dapp-template/frontend/view-functions/getRegistry.ts
+++ b/templates/token-minting-dapp-template/frontend/view-functions/getRegistry.ts
@@ -1,0 +1,12 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+export const getRegistry = async () => {
+  const registry = await aptosClient().view<[[{ inner: string }]]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_registry`,
+    },
+  });
+  return registry[0];
+};

--- a/templates/token-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
+++ b/templates/token-minting-dapp-template/frontend/view-functions/getUserMintBalance.ts
@@ -1,0 +1,19 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+import { aptosClient } from "@/utils/aptosClient";
+import { MODULE_ADDRESS } from "@/constants";
+
+type GetUserMintBalanceArguments = {
+  fa_address: string;
+  user_address: string;
+};
+
+export const getUserMintBalance = async ({ fa_address, user_address }: GetUserMintBalanceArguments) => {
+  const userMintedAmount = await aptosClient().view<[string]>({
+    payload: {
+      function: `${AccountAddress.from(MODULE_ADDRESS)}::launchpad::get_mint_balance`,
+      functionArguments: [fa_address, user_address],
+    },
+  });
+
+  return Number(userMintedAmount[0]);
+};


### PR DESCRIPTION
- Add new view function to return user mint balance
- Store mint balance (i.e. how many token left to mint) instead of how many user has minted in the tracker, this is to keep consistency with token minter contract because token minter tracks balance left to mint instead of minted so far.
- Add a flag to config that can disable / enable mint

<img width="1317" alt="Screenshot 2024-08-22 at 3 34 58 PM" src="https://github.com/user-attachments/assets/a9797457-6608-492b-a648-05c3167e9b3a">

<img width="1331" alt="Screenshot 2024-08-22 at 3 32 56 PM" src="https://github.com/user-attachments/assets/412e16bb-d338-47b2-b965-aa7626fa6bd9">
