### PR TITLE
Update next steps instructions and update README file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Rename `collection_id` to `collection_address` in the NFT minting template
 - Move `collection_address` and `fa_address` from `config.ts` to the `.env` file in the minting templates
 - Rename template `move` folder to `contract`
+- Update next steps instructions when generating a template to follow README file
+- Make sure each temlpate README file mentions the template doc on aptos.dev
 
 # 0.0.23 (2024-08-21)
 

--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -1,4 +1,3 @@
-
 import { green, bold, blue } from "kolorist";
 import path from "path";
 import { fileURLToPath } from "node:url";
@@ -155,7 +154,9 @@ export async function generateDapp(selection: Selections) {
 
     console.log(bold("\nNext steps:"));
 
-    console.log(green(`\nRun: cd ${projectName} && npm run dev`));
+    console.log(green(`\nRun: cd ${projectName}`));
+
+    console.log(green(`\nOpen in your favorite IDE && follow the README file`));
 
     console.log("\n");
   } catch (error: any) {

--- a/templates/boilerplate-template/README.md
+++ b/templates/boilerplate-template/README.md
@@ -1,15 +1,21 @@
 ## Create Aptos Dapp Boilerplate Template
 
-The Boilerplate template provides a starter dapp with all necessary dapp infrastructure and a simple wallet info implementation.
+The Boilerplate template provides a starter dapp with all necessary dapp infrastructure and a simple wallet info implementation, transfer APT and a simple message board functionality to send and read a message on chain.
+
+## Read the Boilerplate template docs
+To get started with the Boilerplate template and learn more about the template functionality and usage, head over to the [Boilerplate template docs](https://aptos.dev/en/build/create-aptos-dapp/templates/boilerplate) 
 
 
 ## The Boilerplate template provides:
 
-- **Folder structure** - A pre-made dapp folder structure with a `frontend` and `move` folders.
+- **Folder structure** - A pre-made dapp folder structure with a `frontend` and `contract` folders.
 - **Dapp infrastructure** - All required dependencies a dapp needs to start building on the Aptos network.
 - **Wallet Info implementation** - Pre-made `WalletInfo` components to demonstrate how one can use to read a connected Wallet info.
+- **Trasnfer APT implementation** - Pre-made `transfer` components to send APT to an address.
+- **Message board functionality implementation** - Pre-made `message` components to send and read a message on chain
 
-### What tools the template uses?
+
+## What tools the template uses?
 
 - React framework
 - Vite development tool
@@ -18,7 +24,7 @@ The Boilerplate template provides a starter dapp with all necessary dapp infrast
 - Aptos Wallet Adapter
 - Node based Move commands
 
-### What Move commands are available?
+## What Move commands are available?
 
 The tool utilizes [aptos-cli npm package](https://github.com/aptos-labs/aptos-cli) that lets us run Aptos CLI in a Node environment.
 

--- a/templates/nft-minting-dapp-template/README.md
+++ b/templates/nft-minting-dapp-template/README.md
@@ -1,16 +1,17 @@
-## Create Aptos Dapp Digital Asset Template
+## Create Aptos Dapp NFT minting dapp Template
 
 Digital Assets are the NFT standard for Aptos. The Digital Asset template provides an end-to-end NFT minting dapp with a beautiful pre-made UI users can quickly adjust and deploy into a live server.
 
-Read more about how to use the template [here](https://aptos.dev/create-aptos-dapp/templates/digital-asset)
+## Read the NFT minting dapp template docs
+To get started with the NFT minting dapp template and learn more about the template functionality and usage, head over to the [NFT minting dapp template docs](https://aptos.dev/en/build/create-aptos-dapp/templates/nft-minting-dapp) 
 
-## The Digital Asset template provides 3 pages:
+## The NFT minting dapp template provides 3 pages:
 
 - **Public Mint NFT Page** - A page for the public to mint NFTs.
 - **Create Collection Page** - A page for creating new NFT collections. This page is not accessible on production.
 - **My Collections Page** - A page to view all the collections created under the current Move module (smart contract). This page is not accessible on production.
 
-### What tools the template uses?
+## What tools the template uses?
 
 - React framework
 - Vite development tool
@@ -19,7 +20,7 @@ Read more about how to use the template [here](https://aptos.dev/create-aptos-da
 - Aptos Wallet Adapter
 - Node based Move commands
 
-### What Move commands are available?
+## What Move commands are available?
 
 The tool utilizes [aptos-cli npm package](https://github.com/aptos-labs/aptos-cli) that lets us run Aptos CLI in a Node environment.
 

--- a/templates/token-minting-dapp-template/README.md
+++ b/templates/token-minting-dapp-template/README.md
@@ -1,8 +1,10 @@
-## Create Aptos Dapp Fungible Asset Template
+## Create Aptos Dapp Token minting dapp Template
 
-The Fungible Asset template provides an end-to-end Fungible Asset minting dapp with a beautiful pre-made UI users can quickly adjust and deploy into a live server.
+The Token minting dapp template provides an end-to-end Fungible Asset minting dapp with a beautiful pre-made UI users can quickly adjust and deploy into a live server.
 
-Read more about how to use the template [here](https://aptos.dev/create-aptos-dapp/templates/fungible-asset)
+
+## Read the Token minting dapp template docs
+To get started with the Token minting dapp template and learn more about the template functionality and usage, head over to the [Token minting dapp template docs](https://aptos.dev/create-aptos-dapp/templates/fungible-asset) 
 
 ## The Fungible Asset template provides 3 pages:
 
@@ -10,7 +12,7 @@ Read more about how to use the template [here](https://aptos.dev/create-aptos-da
 - **Create Fungible Asset page** - A page for creating new asset. This page is not accessible on production.
 - **My Fungible Assets page** - A page to view all the assets created under the current Move module (smart contract). This page is not accessible on production.
 
-### What tools the template uses?
+## What tools the template uses?
 
 - React framework
 - Vite development tool
@@ -19,7 +21,7 @@ Read more about how to use the template [here](https://aptos.dev/create-aptos-da
 - Aptos Wallet Adapter
 - Node based Move commands
 
-### What Move commands are available?
+## What Move commands are available?
 
 The tool utilizes [aptos-cli npm package](https://github.com/aptos-labs/aptos-cli) that lets us run Aptos CLI in a Node environment.
 

--- a/templates/token-staking-dapp-template/README.md
+++ b/templates/token-staking-dapp-template/README.md
@@ -1,4 +1,9 @@
-# Create Aptos Dapp Token Staking Template
+# Create Aptos Dapp Token staking dapp Template
+
+The Token staking dapp template provides an end-to-end Staking dapp with a beautiful pre-made UI users can quickly adjust and deploy into a live server.
+
+## Read the Token staking dapp template docs
+To get started with the Token staking dapp template and learn more about the template functionality and usage, head over to the [Token staking dapp template docs](https://aptos.dev/en/build/create-aptos-dapp/templates/token-staking-dapp) 
 
 ## Overview
 
@@ -20,7 +25,7 @@
 
 ## Limitation
 
-For simplicity of the template, we didn't implement the function for the reward provider to claim back any orphaned reward after the duration has passed. There are are multiple ways to implement this, the simplest way is to transfer all the reward left from reward store after the duration has passed, but this makes anyone who still has pending claim reward have no reward to claim.
+For simplicity of the template, we didn't implement the function for the reward provider to claim back any orphaned reward after the duration has passed. There are multiple ways to implement this, the simplest way is to transfer all the reward left from reward store after the duration has passed, but this makes anyone who still has pending claim reward have no reward to claim.
 
 ## The Token Staking Template provides:
 


### PR DESCRIPTION
Based on user feedbacks, we noticed that
1. Instruct devs to start the dapp after the template generation flow doesnt make sense as they dont really know what to do with it.
2. Developers miss the documentation link.

This PR Instruct devs to read the README file on template generation and makes sure each template README file mentions the docs on aptos.dev