### PR TITLE
Support popular wallets in the wallet selector by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 # Unreleased
 
 - Add a `WrongNetworkAlert` component to all examples to show when the user is on the wrong network
+- Support popular wallets in the wallet selector by default
 
 # 0.0.25 (2024-09-11)
 

--- a/examples/aptogotchi-random-mint/src/context/WalletProvider.tsx
+++ b/examples/aptogotchi-random-mint/src/context/WalletProvider.tsx
@@ -9,6 +9,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
     >
       {children}
     </AptosWalletAdapterProvider>

--- a/examples/aptos-friend/frontend/components/WalletProvider.tsx
+++ b/examples/aptos-friend/frontend/components/WalletProvider.tsx
@@ -12,6 +12,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/boilerplate-template/frontend/components/WalletProvider.tsx
+++ b/templates/boilerplate-template/frontend/components/WalletProvider.tsx
@@ -12,6 +12,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/boilerplate-template/package.json
+++ b/templates/boilerplate-template/package.json
@@ -17,8 +17,8 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
-    "@aptos-labs/wallet-adapter-react": "^3.5.0",
+    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",

--- a/templates/nextjs-boilerplate-template/package.json
+++ b/templates/nextjs-boilerplate-template/package.json
@@ -17,8 +17,8 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
-    "@aptos-labs/wallet-adapter-react": "^3.5.0",
+    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",

--- a/templates/nextjs-boilerplate-template/src/components/WalletProvider.tsx
+++ b/templates/nextjs-boilerplate-template/src/components/WalletProvider.tsx
@@ -14,6 +14,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/nft-minting-dapp-template/frontend/components/WalletProvider.tsx
+++ b/templates/nft-minting-dapp-template/frontend/components/WalletProvider.tsx
@@ -11,6 +11,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/nft-minting-dapp-template/package.json
+++ b/templates/nft-minting-dapp-template/package.json
@@ -17,8 +17,8 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
-    "@aptos-labs/wallet-adapter-react": "^3.5.0",
+    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/templates/token-minting-dapp-template/frontend/components/WalletProvider.tsx
+++ b/templates/token-minting-dapp-template/frontend/components/WalletProvider.tsx
@@ -12,6 +12,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/token-minting-dapp-template/package.json
+++ b/templates/token-minting-dapp-template/package.json
@@ -17,8 +17,8 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
-    "@aptos-labs/wallet-adapter-react": "^3.5.0",
+    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/templates/token-staking-dapp-template/frontend/components/WalletProvider.tsx
+++ b/templates/token-staking-dapp-template/frontend/components/WalletProvider.tsx
@@ -12,6 +12,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
     <AptosWalletAdapterProvider
       autoConnect={true}
       dappConfig={{ network: NETWORK }}
+      optInWallets={["Continue with Google","Petra","Nightly","Pontem Wallet", "Mizu Wallet"]}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/templates/token-staking-dapp-template/package.json
+++ b/templates/token-staking-dapp-template/package.json
@@ -17,8 +17,8 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
-    "@aptos-labs/wallet-adapter-react": "^3.5.0",
+    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",


### PR DESCRIPTION
Based on user feedback, unknown wallets confusing them, i.e the `Dev T Wallet` which is mostly popular in Korea.

This PR opt in by default to the most popular wallets.