### PR TITLE
Upgrade aptos ts sdk dependency to `^1.28.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 - Add a `WrongNetworkAlert` component to all examples to show when the user is on the wrong network
 - Support popular wallets in the wallet selector by default
 - Rename contract directory from `move` to `contract` in aptos-friend example
+- Upgrade aptos `@aptos-labs/ts-sdk` dependency to ^1.28.0
 
 # 0.0.25 (2024-09-11)
 

--- a/examples/aptogotchi-keyless/package.json
+++ b/examples/aptogotchi-keyless/package.json
@@ -13,7 +13,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.27.0",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.5.10",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/examples/aptogotchi-random-mint/package.json
+++ b/examples/aptogotchi-random-mint/package.json
@@ -13,7 +13,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.27.0",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.5.10",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/examples/aptos-friend/package.json
+++ b/examples/aptos-friend/package.json
@@ -18,7 +18,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.27.0",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.5.10",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "type": "module",
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "commander": "^12.1.0",
     "kolorist": "^1.8.0",
     "ora": "^8.0.1",

--- a/templates/boilerplate-template/package.json
+++ b/templates/boilerplate-template/package.json
@@ -17,7 +17,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/templates/nextjs-boilerplate-template/package.json
+++ b/templates/nextjs-boilerplate-template/package.json
@@ -17,7 +17,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/templates/nft-minting-dapp-template/package.json
+++ b/templates/nft-minting-dapp-template/package.json
@@ -17,7 +17,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/templates/token-minting-dapp-template/package.json
+++ b/templates/token-minting-dapp-template/package.json
@@ -17,7 +17,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@irys/sdk": "^0.2.1",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/templates/token-staking-dapp-template/package.json
+++ b/templates/token-staking-dapp-template/package.json
@@ -17,7 +17,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.27.1",
+    "@aptos-labs/ts-sdk": "^1.28.0",
     "@aptos-labs/wallet-adapter-react": "^3.6.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-collapsible": "^1.1.0",


### PR DESCRIPTION
Upgrading the aptos-ts-sdk version following a hot fix https://github.com/aptos-labs/aptos-ts-sdk/pull/513

Ideally, the tool should install latest ts-sdk `1.x.x` version, but bumping the dependency version just to be safe