### PR TITLE
Install the Aptos cli as part of the wizard setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 - Add new custom indexer template
 - Fix NFT and Token minting dapps navigation UI issues
+- Install the Aptos CLI as part of the wizard setup
 
 # 0.0.30 (2024-09-26)
 

--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -12,6 +12,7 @@ import { copy } from "./utils/helpers.js";
 import { installDependencies } from "./utils/installDependencies.js";
 import { generateTemplateEnvFile } from "./utils/generateTemplateEnvFile.js";
 import { getTemplateDirectory } from "./utils/resolveTemplateDirectory.js";
+import { installAptosCli } from "./utils/installAptosCli.js";
 
 const spinner = (text) => ora({ text, stream: process.stdout, color: "green" });
 let currentSpinner: Ora | null = null;
@@ -78,6 +79,21 @@ export async function generateDapp(selection: Selections) {
 
     scaffoldingSpinner.succeed();
 
+    // Install Aptos CLI
+    const aptosCliSpinner = spinner(`Installing Aptos CLI`).start();
+    currentSpinner = aptosCliSpinner;
+
+    try {
+      await installAptosCli();
+      aptosCliSpinner.succeed();
+    } catch (error) {
+      console.log(
+        `Failed to install Aptos CLI, will try to install it later, error: ${error}`
+      );
+      aptosCliSpinner.fail();
+    }
+
+    // Change to target directory
     process.chdir(targetDirectory);
 
     // Generate and write to template .env file
@@ -101,7 +117,7 @@ export async function generateDapp(selection: Selections) {
     );
 
     const npmSpinner = spinner(`Installing the dependencies\n`).start();
-
+    currentSpinner = npmSpinner;
     // Install dependencies
     await installDependencies(context);
 

--- a/src/utils/installAptosCli.ts
+++ b/src/utils/installAptosCli.ts
@@ -1,0 +1,39 @@
+import { platform } from "os";
+import { spawn } from "child_process";
+
+/**
+ * Install the aptos cli node wrapper while suppressing the process log output
+ */
+export const installAptosCli = async () => {
+  return new Promise((resolve, reject) => {
+    const currentPlatform = platform();
+    let childProcess;
+    let stdout = "";
+    let stderr = "";
+
+    // Check if current OS is Windows
+    if (currentPlatform === "win32") {
+      childProcess = spawn("npx", ["aptos"], { shell: true });
+    } else {
+      childProcess = spawn("npx", ["aptos"]);
+    }
+
+    // Collect stdout and stderr without piping to the console
+    childProcess.stdout.on("data", (data) => {
+      stdout += data.toString(); // Accumulate stdout data
+    });
+
+    childProcess.stderr.on("data", (data) => {
+      stderr += data.toString(); // Accumulate stderr data
+    });
+
+    // Listen for the process to close and resolve or reject the promise
+    childProcess.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout); // Resolve with the collected stdout data
+      } else {
+        reject();
+      }
+    });
+  });
+};


### PR DESCRIPTION
Following openUX feedback - Instead of installing the Aptos cli when user runs any of the `npm run move` commands, we install it as part of the wizard setup flow