### PR TITLE
Install aptos cli after dependencies are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 # Unreleased
 
+- Install Aptos CLI after dependencies are installed
+
 # 0.0.31 (2024-09-30)
 
 - Add new custom indexer template

--- a/src/generateDapp.ts
+++ b/src/generateDapp.ts
@@ -79,20 +79,6 @@ export async function generateDapp(selection: Selections) {
 
     scaffoldingSpinner.succeed();
 
-    // Install Aptos CLI
-    const aptosCliSpinner = spinner(`Installing Aptos CLI`).start();
-    currentSpinner = aptosCliSpinner;
-
-    try {
-      await installAptosCli();
-      aptosCliSpinner.succeed();
-    } catch (error) {
-      console.log(
-        `Failed to install Aptos CLI, will try to install it later, error: ${error}`
-      );
-      aptosCliSpinner.fail();
-    }
-
     // Change to target directory
     process.chdir(targetDirectory);
 
@@ -116,11 +102,26 @@ export async function generateDapp(selection: Selections) {
       `\nNeed to install dependencies, this might take a while - in the meantime:\n ${docsInstructions}\n`
     );
 
+    // Install dependencies
     const npmSpinner = spinner(`Installing the dependencies\n`).start();
     currentSpinner = npmSpinner;
-    // Install dependencies
     await installDependencies(context);
+    npmSpinner.succeed();
 
+    // Install Aptos CLI
+    const aptosCliSpinner = spinner(`Installing Aptos CLI`).start();
+    currentSpinner = aptosCliSpinner;
+    try {
+      await installAptosCli();
+      aptosCliSpinner.succeed();
+    } catch (error) {
+      console.log(
+        `\nFailed to install Aptos CLI, will try to install it later, error: ${error}`
+      );
+      aptosCliSpinner.fail();
+    }
+
+    // Record telemetry
     await recordTelemetry({
       command: "npx create-aptos-dapp",
       project_name: selection.projectName,
@@ -130,9 +131,6 @@ export async function generateDapp(selection: Selections) {
       network: selection.network,
       signing_option: selection.signingOption,
     });
-
-    npmSpinner.succeed();
-    currentSpinner = npmSpinner;
 
     // Log next steps
     console.log(


### PR DESCRIPTION
When installing the aptos cli we use `npx` command to trigger the npm bin, but since we do it before dependencies are installed it is failing.

Moving the aptos cli installation to happen after dependencies are installed.