### PR TITLE
Remove `VitePWA`  plugin from Boilerplate templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the create-aptos-dapp tool will be captured in this file.
 
 # Unreleased
 
+- Remove `VitePWA` plugin from Boilerplate templates
+
 # 0.1.0 (2025-05-06)
 
 - Remove telegram mini app template and mizu wallet given telegram mini app only supports Ton chain now

--- a/templates/boilerplate-template/package.json
+++ b/templates/boilerplate-template/package.json
@@ -52,7 +52,6 @@
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
     "vite-plugin-notifier": "^0.1.5",
-    "vite-plugin-pwa": "^0.20.5",
     "tree-kill": "1.2.2",
     "dotenv": "16.3.1",
     "vercel": "^35.2.4"

--- a/templates/boilerplate-template/vite.config.ts
+++ b/templates/boilerplate-template/vite.config.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import { VitePWA } from "vite-plugin-pwa";
 
 export default defineConfig({
   build: {
@@ -12,35 +11,6 @@ export default defineConfig({
   },
   plugins: [
     react(),
-    VitePWA({
-      disable: false,
-      registerType: "autoUpdate",
-      manifest: {
-        name: "Aptos Fullstack Template",
-        short_name: "Aptos Template",
-        icons: [
-          {
-            src: "/icons/icon-192x192.png",
-            sizes: "192x192",
-            type: "image/png",
-            purpose: "any maskable",
-          },
-          {
-            src: "/icons/icon-384x384.png",
-            sizes: "384x384",
-            type: "image/png",
-          },
-          {
-            src: "/icons/icon-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-          },
-        ],
-        start_url: "/",
-        display: "standalone",
-        orientation: "portrait",
-      },
-    }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
This breaks the `build` because of max size, might be because of the ts-sdk size, but for now removing this plugin to unblock users