### PR TITLE
fix: update remaining Geomi API key link in custom-indexer template

### DIFF
--- a/templates/custom-indexer-template/indexer/example.config.yaml
+++ b/templates/custom-indexer-template/indexer/example.config.yaml
@@ -9,7 +9,7 @@ server_config:
     starting_version: 5936597868
     # At which tx version to stop indexing
     # request_ending_version: 10000
-    # Go to https://developers.aptoslabs.com/ to create a project and get an API token
+    # Go to https://geomi.dev/docs/api-keys to create a project and get an API token
     auth_token: "auth_token_you_can_get_from_aptos_build"
     request_name_header: ""
   db_config:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #307

## Summary

The init workflow prompt in `src/workflow/workflowOptions.ts` was already updated to `https://geomi.dev/docs/api-keys` in v0.2.0 (#308). This PR updates the last remaining `developers.aptoslabs.com` reference in the custom-indexer-template example config to match.

## Changes

- Update the API token comment in `templates/custom-indexer-template/indexer/example.config.yaml` from `https://developers.aptoslabs.com/` to `https://geomi.dev/docs/api-keys`

## Verification

- Confirmed the init prompt in `src/workflow/workflowOptions.ts` and the published `create-aptos-dapp@0.3.1` package already use the correct Geomi URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb6b5b77-c51a-47ee-8349-0eb1774e0c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb6b5b77-c51a-47ee-8349-0eb1774e0c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

