### PR TITLE
Populate dev-addresses

### DIFF
--- a/examples/aptogotchi-keyless/contract/Move.toml
+++ b/examples/aptogotchi-keyless/contract/Move.toml
@@ -5,6 +5,9 @@ version = "1.0.0"
 [addresses]
 aptogotchi_addr = "_"
 
+[dev-addresses]
+aptogotchi_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }

--- a/examples/aptogotchi-random-mint/contract/Move.toml
+++ b/examples/aptogotchi-random-mint/contract/Move.toml
@@ -5,6 +5,9 @@ version = "1.0.0"
 [addresses]
 aptogotchi_addr = "_"
 
+[dev-addresses]
+aptogotchi_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }

--- a/examples/aptos-friend/contract/Move.toml
+++ b/examples/aptos-friend/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 aptos_friend_addr = "_"
 
+[dev-addresses]
+aptos_friend_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/examples/build-e2e-dapp-guide/contract/Move.toml
+++ b/examples/build-e2e-dapp-guide/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 todolist_addr='_'
 
+[dev-addresses]
+todolist_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/template-live-examples/boilerplate/contract/Move.toml
+++ b/template-live-examples/boilerplate/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 message_board_addr = "_"
 
+[dev-addresses]
+message_board_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/template-live-examples/nft-minting/contract/Move.toml
+++ b/template-live-examples/nft-minting/contract/Move.toml
@@ -8,6 +8,11 @@ launchpad_addr = "_"
 initial_creator_addr = "_"
 minter = "_"
 
+[dev-addresses]
+launchpad_addr = "0x100"
+initial_creator_addr = "0x101"
+minter = "0x102"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }

--- a/template-live-examples/token-minting/contract/Move.toml
+++ b/template-live-examples/token-minting/contract/Move.toml
@@ -7,6 +7,10 @@ authors = []
 launchpad_addr = '_'
 initial_creator_addr = "_"
 
+[dev-addresses]
+launchpad_addr = "0x100"
+initial_creator_addr = "0x101"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/template-live-examples/token-staking/contract/Move.toml
+++ b/template-live-examples/token-staking/contract/Move.toml
@@ -8,6 +8,11 @@ stake_pool_addr = "_"
 fa_obj_addr = "_"
 initial_reward_creator_addr = "_"
 
+[dev-addresses]
+stake_pool_addr = "0x100"
+fa_obj_addr = "0x200"
+initial_reward_creator_addr = "0x300"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/boilerplate-template/contract/Move.toml
+++ b/templates/boilerplate-template/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 message_board_addr = "_"
 
+[dev-addresses]
+message_board_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/contract-boilerplate-template/contract/Move.toml
+++ b/templates/contract-boilerplate-template/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 message_board_addr = "_"
 
+[dev-addresses]
+message_board_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/custom-indexer-template/contract/Move.toml
+++ b/templates/custom-indexer-template/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 message_board_addr = "_"
 
+[dev-addresses]
+message_board_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/nextjs-boilerplate-template/contract/Move.toml
+++ b/templates/nextjs-boilerplate-template/contract/Move.toml
@@ -6,6 +6,9 @@ authors = []
 [addresses]
 message_board_addr = "_"
 
+[dev-addresses]
+message_board_addr = "0x100"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/nft-minting-dapp-template/contract/Move.toml
+++ b/templates/nft-minting-dapp-template/contract/Move.toml
@@ -8,6 +8,11 @@ launchpad_addr = "_"
 initial_creator_addr = "_"
 minter = "_"
 
+[dev-addresses]
+launchpad_addr = "0x100"
+initial_creator_addr = "0x101"
+minter = "0x102"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }

--- a/templates/token-minting-dapp-template/contract/Move.toml
+++ b/templates/token-minting-dapp-template/contract/Move.toml
@@ -7,6 +7,10 @@ authors = []
 launchpad_addr = '_'
 initial_creator_addr = "_"
 
+[dev-addresses]
+launchpad_addr = "0x100"
+initial_creator_addr = "0x101"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/templates/token-staking-dapp-template/contract/Move.toml
+++ b/templates/token-staking-dapp-template/contract/Move.toml
@@ -8,6 +8,11 @@ stake_pool_addr = "_"
 fa_obj_addr = "_"
 initial_reward_creator_addr = "_"
 
+[dev-addresses]
+stake_pool_addr = "0x100"
+fa_obj_addr = "0x200"
+initial_reward_creator_addr = "0x300"
+
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Populate `[dev-addresses]` in all Move.toml files so users can quickly run `aptos move compile` and `aptos move test` with the `--dev` flag without needing `.env` or named address overrides.

## Changes

Added `[dev-addresses]` sections to all 15 `Move.toml` files across `templates/`, `examples/`, and `template-live-examples/`. Dev address values match the `namedAddresses` already used in each template's `scripts/move/test.js`:

| Template type | Dev addresses |
|---|---|
| Message board (boilerplate, contract, nextjs, custom-indexer) | `message_board_addr = "0x100"` |
| Token minting | `launchpad_addr = "0x100"`, `initial_creator_addr = "0x101"` |
| NFT minting | `launchpad_addr = "0x100"`, `initial_creator_addr = "0x101"`, `minter = "0x102"` |
| Token staking | `stake_pool_addr = "0x100"`, `fa_obj_addr = "0x200"`, `initial_reward_creator_addr = "0x300"` |
| Aptogotchi examples | `aptogotchi_addr = "0x100"` |
| Aptos Friend | `aptos_friend_addr = "0x100"` |
| Build e2e dapp guide | `todolist_addr = "0x100"` |

## Example

```toml
[addresses]
message_board_addr = "_"

[dev-addresses]
message_board_addr = "0x100"
```

Users can now run:

```bash
cd contract
aptos move compile --dev
aptos move test --dev
```

## Verification

Verified with Aptos CLI 9.4.0:
- `templates/boilerplate-template` — compile and test pass with `--dev`
- `templates/token-minting-dapp-template` — test pass with `--dev`
- `templates/token-staking-dapp-template` — test pass with `--dev`
- `examples/aptogotchi-keyless` — test pass with `--dev`
- `examples/build-e2e-dapp-guide` — test pass with `--dev`

Fixes #142
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-826283b3-b4fd-428b-b8f6-dab5d3209232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-826283b3-b4fd-428b-b8f6-dab5d3209232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

